### PR TITLE
chore: project-review remediation + image hardening + test coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Without a .dockerignore, `docker build` ships the entire repo to BuildKit
+# (including .git/, large local artifacts, and any local .env/credentials),
+# which slows every build, fragments layer caching, and risks leaking
+# secrets into intermediate layers. Keep this list minimal — Go's `go
+# build` happily ignores files it doesn't need; the only items that
+# MUST be excluded are credentials and large irrelevant trees.
+
+# Version control history (~unbounded growth)
+.git/
+
+# Local build artifacts
+.bin/
+dist/
+
+# IDE / editor
+.idea/
+.vscode/
+
+# Claude Code harness scratch
+.claude/
+
+# Local env / credentials — never ship into a build context
+.env
+.env.*
+
+# Rendered Kafka client config (contains live API keys when populated)
+kafka.properties
+
+# Mise / version-manager runtime state
+.mise/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,12 +291,15 @@ jobs:
     # find binaries but no image (or vice versa). On non-tag pushes,
     # release-binaries is skipped (treated as success by `needs:`).
     needs: [changes, test, static-check, build, release-binaries]
-    # Explicit `if:` replaces the default success-of-all-needs check. Use
-    # `success()` so the chain still considers skipped needs (release-
-    # binaries is tag-only and is skipped on non-tag pushes — that's
-    # success-equivalent; failures and cancels still block).
+    # Explicit `if:` replaces the default success-of-all-needs check.
+    # `success()` is too strict here — it returns false when ANY need is
+    # skipped, including the tag-only `release-binaries` job that skips
+    # legitimately on non-tag pushes. Use `!failure() && !cancelled()`
+    # which evaluates true when no need failed/cancelled (skipped is
+    # neither, so it's accepted as the normal non-tag behaviour).
     if: |
-      success() && (github.ref_type == 'tag' || needs.changes.outputs.code == 'true')
+      !failure() && !cancelled() &&
+      (github.ref_type == 'tag' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,10 +372,13 @@ jobs:
       - name: Smoke test
         # Kafka consumer has no standalone mode; full boot requires a
         # broker. Verify the binary is present and executable instead.
+        # `file` is not in the minimal alpine runtime image, so the test
+        # relies on `test -x` only (sufficient — confirms the binary
+        # exists and is executable for the runtime user).
         run: |
           set -euo pipefail
           docker run --rm --entrypoint=/bin/sh kafka-confluent-go-consumer:scan \
-            -c 'test -x /consumer && file /consumer || exit 1'
+            -c 'test -x /consumer'
           echo "PASS: /consumer binary present and executable"
 
       - name: Log in to GHCR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,7 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claude/**'
-      - '**.png'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claude/**'
-      - '**.png'
   workflow_call:
 
 concurrency:
@@ -45,24 +31,70 @@ jobs:
           GO_VERSION=$(grep -E '^go [0-9]+\.[0-9]+' go.mod | awk '{print $2}' | cut -d. -f1,2)
           echo "version=v${GO_VERSION}" >> "$GITHUB_OUTPUT"
 
+  # `changes` is the path-filter detector. Heavy jobs (`static-check`,
+  # `test`, `integration-test`, `e2e-compose`, `e2e`, `build`) gate on
+  # `needs.changes.outputs.code == 'true'`. Doc-only PRs/pushes leave
+  # `code=false`; the heavy jobs report `result: 'skipped'`, which the
+  # `ci-pass` aggregator treats as success — required-status-checks
+  # under Repository Rulesets stay green without forcing every doc PR
+  # through the full pipeline. Trigger-level `paths-ignore` would
+  # deadlock with Rulesets (no run = no `ci-pass` status).
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed files
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!**.png'
+              - '!.claude/**'
+
   static-check:
+    needs: [changes]
+    if: success() && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - name: Set up mise (Go + lint/security toolchain)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-
 
       - name: Static check
         run: make static-check
 
   test:
-    needs: [setup, static-check]
+    needs: [setup, changes, static-check]
+    if: success() && needs.changes.outputs.code == 'true'
     timeout-minutes: 20
     strategy:
       matrix:
@@ -74,11 +106,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - name: Set up mise (Go + lint/security toolchain)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-
 
       - name: Create temporary .env
         run: touch .env
@@ -87,18 +129,29 @@ jobs:
         run: make test
 
   integration-test:
-    needs: [setup, static-check]
+    needs: [setup, changes, static-check]
+    if: success() && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - name: Set up mise (Go + lint/security toolchain)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-
 
       - name: Create temporary .env
         run: touch .env
@@ -106,56 +159,9 @@ jobs:
       - name: Integration test
         run: make integration-test
 
-  e2e-compose:
-    needs: [setup, static-check]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: E2E compose
-        run: make e2e-compose
-
-  e2e:
-    needs: [setup, static-check]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Install KinD + kubectl
-        env:
-          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-          KIND_VERSION: v0.31.0
-          # renovate: datasource=github-releases depName=kubernetes/kubernetes
-          KUBECTL_VERSION: v1.35.3
-        run: |
-          set -euo pipefail
-          curl -fsSLo /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
-          chmod +x /tmp/kind
-          sudo mv /tmp/kind /usr/local/bin/kind
-          # kubectl is preinstalled on GitHub Actions ubuntu-latest but not
-          # in act's catthehacker/ubuntu:act-latest — install unconditionally
-          # so local (act) and remote (GitHub) both work.
-          curl -fsSLo /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          chmod +x /tmp/kubectl
-          sudo mv /tmp/kubectl /usr/local/bin/kubectl
-          kind version
-          kubectl version --client
-
-      - name: E2E KinD
-        run: make e2e
-
   build:
-    needs: [setup, static-check]
+    needs: [setup, changes, static-check]
+    if: success() && needs.changes.outputs.code == 'true'
     timeout-minutes: 20
     strategy:
       matrix:
@@ -169,17 +175,60 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - name: Set up mise (Go + lint/security toolchain)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-
 
       - name: Create temporary .env
         run: touch .env
 
       - name: Build
         run: make build
+
+  e2e-compose:
+    needs: [setup, changes, static-check, build, test]
+    if: success() && needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: E2E compose
+        run: make e2e-compose
+
+  e2e:
+    needs: [setup, changes, static-check, build, test]
+    if: success() && needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Install KinD + kubectl
+        run: make kind-tools-install
+
+      - name: E2E KinD
+        run: make e2e
 
   release-binaries:
     if: github.ref_type == 'tag'
@@ -229,18 +278,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker:
-    if: github.ref_type == 'tag'
-    # Serialize after release-binaries so a tag either produces BOTH the
-    # GitHub Release tarballs AND the ghcr.io image, or neither — avoiding
-    # half-released tags where users pinning to v1.2.3 find binaries but no
-    # image (or vice versa). Trade-off: ~2-4 min longer wall time on tag.
-    needs: [test, static-check, build, release-binaries]
+    # Runs on every code-changing push (catches multi-arch build regressions
+    # + cosign installer breakage on the commit that introduced them, not
+    # release day). Step-level `if:` on Login / Push / Cosign install / Sign
+    # gates the tag-only behaviour; the multi-arch build itself runs every
+    # time as validation, with `push: ${{ startsWith(...) }}` deciding
+    # whether to publish.
+    #
+    # On tag pushes, serializes after release-binaries so a tag either
+    # produces BOTH the GitHub Release tarballs AND the ghcr.io image, or
+    # neither — avoiding half-released tags where users pinning to v1.2.3
+    # find binaries but no image (or vice versa). On non-tag pushes,
+    # release-binaries is skipped (treated as success by `needs:`).
+    needs: [changes, test, static-check, build, release-binaries]
+    # Explicit `if:` replaces the default success-of-all-needs check. Use
+    # `success()` so the chain still considers skipped needs (release-
+    # binaries is tag-only and is skipped on non-tag pushes — that's
+    # success-equivalent; failures and cancels still block).
+    if: |
+      success() && (github.ref_type == 'tag' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
-      packages: write
-      id-token: write  # cosign keyless OIDC signing
+      packages: write    # exercised only by the tag-gated push step
+      id-token: write    # exercised only by the tag-gated cosign sign step
 
     steps:
       - name: Checkout
@@ -258,9 +320,18 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/kafka-confluent-go-consumer
+          # Repo-namespace path (`<owner>/<repo>/<package>`). User-account
+          # repos require this shape for first-tag bootstrap because
+          # GITHUB_TOKEN cannot CREATE user-namespace packages
+          # (`ghcr.io/<owner>/<package>`) — only repo-namespace packages.
+          # Org accounts work either way; we use repo-namespace
+          # universally for portfolio consistency.
+          images: ghcr.io/${{ github.repository }}/kafka-confluent-go-consumer
+          # Only apply `latest` on tag pushes — on non-tag pushes the
+          # metadata still resolves cleanly (no `:latest` row in the tag
+          # set) and the publish step is skipped via step-level `if:`.
           flavor: |
-            latest=true
+            latest=${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -275,9 +346,6 @@ jobs:
             io.artifacthub.package.maintainers=[{"name":"Andriy Kalashnykov","email":"andriykalashnykov@gmail.com"}]
             io.artifacthub.package.license=MIT
 
-      # =================================================================
-      # GATE 1: Local single-arch build (for scanning + smoke testing)
-      # =================================================================
       - name: Build image for scan
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
@@ -289,9 +357,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # =================================================================
-      # GATE 2: Trivy image scan (CRITICAL/HIGH blocking)
-      # =================================================================
       - name: Trivy image scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
@@ -301,21 +366,17 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
 
-      # =================================================================
-      # GATE 3: Smoke test — verify binary is present and executable
-      # (Kafka consumer has no standalone mode; full boot requires a broker)
-      # =================================================================
       - name: Smoke test
+        # Kafka consumer has no standalone mode; full boot requires a
+        # broker. Verify the binary is present and executable instead.
         run: |
           set -euo pipefail
           docker run --rm --entrypoint=/bin/sh kafka-confluent-go-consumer:scan \
             -c 'test -x /consumer && file /consumer || exit 1'
           echo "PASS: /consumer binary present and executable"
 
-      # =================================================================
-      # All gates passed → publish (cosign-signed post-push)
-      # =================================================================
       - name: Log in to GHCR
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
@@ -332,7 +393,11 @@ jobs:
           # librdkafka links against per-arch Alpine packages, so the same
           # Dockerfile produces a correct binary for each TARGETARCH.
           platforms: linux/amd64,linux/arm64
-          push: true
+          # On non-tag pushes this is a build-only validation run (no
+          # registry push); on tag pushes it actually publishes. The
+          # multi-arch build runs every time so arm64 cross-compile
+          # regressions surface on the commit that introduced them.
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
           provenance: false  # Pattern A — keeps image index free of unknown/unknown entries so GHCR "OS / Arch" tab renders
           sbom: false        # Pattern A — cosign keyless signing below provides supply-chain verification
           tags: ${{ steps.meta.outputs.tags }}
@@ -340,13 +405,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # =================================================================
-      # Post-push: cosign keyless OIDC signing by digest
-      # =================================================================
       - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Sign image with cosign
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.push.outputs.digest }}
@@ -359,11 +423,22 @@ jobs:
           done <<< "${TAGS}"
 
       - name: Output container image digest
+        if: startsWith(github.ref, 'refs/tags/')
         run: echo "${{ steps.push.outputs.digest }}"
 
   ci-pass:
     if: always()
-    needs: [setup, static-check, test, integration-test, e2e-compose, e2e, build, release-binaries, docker]
+    needs:
+      - setup
+      - changes
+      - static-check
+      - test
+      - integration-test
+      - e2e-compose
+      - e2e
+      - build
+      - release-binaries
+      - docker
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,12 @@
 [tools]
 go = "1.26.2"
 node = "24"
+"aqua:golangci/golangci-lint" = "2.11.4"
+"aqua:nektos/act" = "0.2.87"
+"aqua:hadolint/hadolint" = "2.14.0"
+"aqua:securego/gosec" = "2.25.0"
+"aqua:gitleaks/gitleaks" = "8.30.1"
+"aqua:rhysd/actionlint" = "1.7.12"
+"aqua:koalaman/shellcheck" = "0.11.0"
+"aqua:aquasecurity/trivy" = "0.69.3"
+"go:golang.org/x/vuln/cmd/govulncheck" = "1.2.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,24 +7,28 @@ Go-based Confluent Kafka Cloud producer/consumer examples using the [confluent-k
 ## Tech Stack
 
 - **Language**: Go 1.26.2
-- **Kafka Client**: confluent-kafka-go v2.14.0 (CGO, `librdkafka`)
+- **Kafka Client**: confluent-kafka-go v2.14.1 (CGO, `librdkafka`)
 - **Build**: Make, GoReleaser (cross-compilation)
 - **Container**: Docker, Docker Compose
 - **Orchestration**: Kubernetes
 - **CI/CD**: GitHub Actions
-- **Version manager**: mise (`.mise.toml`, `.nvmrc`)
-- **Static analysis**: golangci-lint, gosec, govulncheck, gitleaks, actionlint, shellcheck, hadolint, trivy (filesystem + K8s misconfigs)
-- **Dependency Management**: Renovate
+- **Version manager**: mise (`.mise.toml`, `.nvmrc`) — manages Go, Node, and all host-installed lint/security tools (golangci-lint, gosec, gitleaks, hadolint, trivy, actionlint, shellcheck, govulncheck, act). Note: `node = "24"` is a major-only constraint by design — the renovate-validate target only needs a recent Node 24 line; tightening to a full patch would create churn without value.
+- **Static analysis**: golangci-lint, gosec, govulncheck, gitleaks, actionlint, shellcheck, hadolint, trivy (filesystem + K8s misconfigs), mermaid-cli (diagram parse-check)
+- **Dependency Management**: Renovate (mise + gomod + dockerfile + docker-compose + kubernetes managers; `automergeType: "pr"` because main has the `ci-pass` required check)
 
 ## Project Structure
 
 ```
-producer/          - Kafka producer application
-consumer/          - Kafka consumer application
-internal/          - Shared internal packages
+producer/          - Kafka producer entrypoint (thin shell over internal/producer.Run)
+consumer/          - Kafka consumer entrypoint (thin shell over internal/consumer.Run)
+internal/
+  producer/        - Producer Run loop, applyDefaults, produceWithRetry (unit-tested)
+  consumer/        - Consumer Run loop, applyDefaults (unit-tested)
+  util/            - Env-var → kafka.ConfigMap plumbing (BuildKafkaConfigMap)
+  kafkaroundtrip/  - Integration test: real broker via Testcontainers, produces and consumes
 k8s/               - Kubernetes manifests (ns, cm, sc, deployment, service)
 e2e/               - E2E harness: compose flow + KinD flow + PLAINTEXT fixtures
-scripts/           - Setup scripts (cross-compilation, toolchain install)
+scripts/           - Setup scripts (cross-compilation, toolchain install, kind/kubectl)
 tmpl/              - Template files (.env, kafka.properties, k8s secrets)
 .github/workflows/ - CI/CD workflows
 ```
@@ -53,6 +57,14 @@ make deps-check     # Show required Go version and mise status
 - Requires `.env` file for Kafka credentials (see `tmpl/.env.tmpl`)
 - Requires `kafka.properties` for Kafka config (see `tmpl/kafka.properties.tmpl`)
 - CGO is enabled (required by confluent-kafka-go / librdkafka)
+- `NUM_MESSAGES` env var (optional) overrides the producer's default 10-message run; the e2e-compose harness sets this to fix the publish count for assertion-counting
+
+### Test pyramid
+
+- **Unit** (`make test`): tests against `applyDefaults` helpers, `produceWithRetry` (driven by an injected fake `*kafka.Producer`), `BuildKafkaConfigMap`, and broker-unreachable / ctx-cancel guard rails. Runs in seconds, no Docker.
+- **Integration** (`make integration-test`): `internal/kafkaroundtrip/roundtrip_integration_test.go` — Apache Kafka 3.9.0 KRaft container via Testcontainers. Three tests: end-to-end produce/consume round-trip, ctx-cancel exit, MaxMessages early-return. Tens of seconds; requires Docker.
+- **E2E (compose)** (`make e2e-compose`): `e2e/docker-compose.e2e.yml` boots PLAINTEXT Kafka + builds **both** Dockerfiles (`Dockerfile.consumer` long-lived service, `Dockerfile.producer` one-shot job). Asserts the producer-binary publish path AND the consumer-binary consume path round-trip via a real broker.
+- **E2E (KinD)** (`make e2e`): `e2e/e2e-kind-test.sh` deploys real `k8s/` manifests (with PLAINTEXT overlays in `e2e/k8s/`) into a throwaway KinD cluster. Pins kubectl to `kind-kafka-e2e` context (`KUBECTL=(kubectl --context=kind-kafka-e2e)`) so a sibling project's `kubectl config use-context` cannot redirect calls to the wrong cluster. The Kafka rollout step retries up to 3× to absorb docker.io pull-rate-limit hiccups.
 
 ### Running
 
@@ -101,8 +113,9 @@ Cleanup workflow (`cleanup-runs.yml`) runs weekly to remove old workflow runs (r
 - `GOPRIVATE` set to this repository
 - Binary output directory: `.bin/`
 - Use `make ci` to validate changes locally before pushing
-- mise manages the Go + Node toolchain (`.mise.toml`, `.nvmrc`); CI uses `actions/setup-go` with `go-version-file: go.mod`
-- Tool versions pinned in Makefile (`GOLANGCI_VERSION`, `ACT_VERSION`, `HADOLINT_VERSION`, `GOVULNCHECK_VERSION`, `GOSEC_VERSION`, `GITLEAKS_VERSION`, `ACTIONLINT_VERSION`, `SHELLCHECK_VERSION`, `TRIVY_VERSION`, `MERMAID_CLI_VERSION`) with `# renovate:` inline comments; workflow-level env pins (`KIND_VERSION`, `KUBECTL_VERSION` in `.github/workflows/ci.yml`) are tracked via a second `customManagers` regex in `renovate.json`
+- mise (`.mise.toml`) is the single source of truth for the host toolchain — Go, Node, and all lint/security scanners. `make deps` bootstraps mise and runs `mise install`. CI uses `actions/setup-go` (with `go-version-file: go.mod`) for the Go cache and runs `make deps` for everything else
+- Docker-image-only tool pins (no host install) live in the Makefile with `# renovate:` inline comments: `MERMAID_CLI_VERSION` (mermaid-cli) and `GOLANG_CROSS_VERSION` (goreleaser-cross). `KIND_VERSION` and `KUBECTL_VERSION` live in `scripts/kind-tools-install.sh` (called by `make kind-tools-install` from both local dev and the CI `e2e` job) — tracked by a third `customManagers` regex in `renovate.json`
+- `KUBECTL ?= kubectl` indirection in the Makefile lets `make k8s-deploy KUBECTL='kubectl --context=...'` pin a specific cluster without changing the recipe; the e2e KinD harness pins `kubectl --context=kind-${CLUSTER}` inline (see `e2e/e2e-kind-test.sh`) to defend against sibling projects swapping the global current-context
 
 ## Skills
 

--- a/Dockerfile.consumer
+++ b/Dockerfile.consumer
@@ -9,24 +9,11 @@ RUN apk add --no-cache \
       build-base coreutils make rpm wget curl cyrus-sasl-dev libevent libsasl lz4-dev \
       openssh openssl openssl-dev yajl-dev zlib-dev
 
-#ENV LIBRD_VER=2.3.0
-# Install librdkafka $LIBRD_VER
-# https://gist.github.com/jaihind213/e82d41dc79f52cfa64ca32350bdb27df
-#RUN apk --no-cache add ca-certificates git gcc g++ libtool libc-dev musl-dev pkgconf
-#RUN apk add build-base coreutils make musl-dev rpm wget curl cyrus-sasl-dev libevent libsasl lz4-dev openssh openssl openssl-dev yajl-dev zlib-dev
-
-#RUN echo " ------> Install librdkafka..."
-#RUN apk add --no-cache --virtual .make-deps bash make wget git gcc g++
-#RUN apk add --no-cache musl-dev zlib-dev openssl zstd-dev pkgconfig libc-dev
-#RUN wget https://github.com/edenhill/librdkafka/archive/v${LIBRD_VER}.tar.gz && tar -xvf v${LIBRD_VER}.tar.gz && cd librdkafka-${LIBRD_VER} && ./configure --prefix /usr && make && make install && make clean && rm -rf librdkafka-${LIBRD_VER} && rm -rf v${LIBRD_VER}.tar.gz && apk del .make-deps
-
-#RUN apk add --no-cache --virtual .make-deps bash make wget git gcc g++ && apk add --no-cache musl-dev zlib-dev openssl zstd-dev pkgconfig libc-dev
-#RUN wget https://github.com/edenhill/librdkafka/archive/v${LIBRD_VER}.tar.gz
-#RUN tar -xvf v${LIBRD_VER}.tar.gz && cd librdkafka-${LIBRD_VER} && ./configure --prefix /usr && make && make install
-#RUN export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
-#ENV PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
-
-# https://github.com/confluentinc/confluent-kafka-go/issues/981
+# Linkage notes: confluent-kafka-go links dynamically against librdkafka
+# from Alpine's package; mold cuts ~50% off the link step. Cross-arch
+# builds work because Alpine ships per-arch packages, so the same
+# Dockerfile produces a correct binary for each TARGETARCH.
+# See https://github.com/confluentinc/confluent-kafka-go/issues/981.
 
 WORKDIR /app
 COPY go.mod .

--- a/Dockerfile.consumer
+++ b/Dockerfile.consumer
@@ -22,14 +22,19 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=1 GOOS=linux CGO_LDFLAGS="-fuse-ld=mold -lsasl2" go build -tags musl --ldflags "-w -s" -a -o consumer consumer/consumer.go
 
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS runtime
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime
 WORKDIR /
+# Defence in depth: `apk upgrade` grabs whatever security patches landed
+# in the alpine repos AFTER the pinned base image was built. Renovate
+# bumps the FROM tag on each new alpine release; this line covers the
+# window between releases (e.g. CVE-2026-22184 zlib fix in 1.3.2-r0).
 # Runtime shared libs needed by the CGO-linked consumer binary:
 #   libgcc       — libgcc_s.so.1 (CGO runtime)
 #   librdkafka   — librdkafka.so (pulled from the Kafka client)
 #   cyrus-sasl   — libsasl2.so (linked via -lsasl2 at build time)
 # ca-certificates is required for SASL_SSL bootstrap to a public broker.
-RUN apk add --no-cache libgcc librdkafka cyrus-sasl ca-certificates
+RUN apk upgrade --no-cache && \
+    apk add --no-cache libgcc librdkafka cyrus-sasl ca-certificates
 RUN addgroup -g 1000 srvgroup && adduser -D srvuser -u 1000 -G srvgroup
 COPY --from=builder /app/consumer /
 USER srvuser:srvgroup

--- a/Dockerfile.producer
+++ b/Dockerfile.producer
@@ -1,0 +1,29 @@
+# docker buildx build --platform linux/arm64 --file Dockerfile.producer -t kafka-confluent-go-producer:latest .
+# https://hub.docker.com/_/golang/tags
+FROM golang:1.26.2-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS builder
+
+# librdkafka build deps mirror Dockerfile.consumer — both binaries link
+# against the same native library and need the same Alpine packages.
+RUN apk add --no-cache \
+      mold musl-dev librdkafka-dev ca-certificates git gcc g++ libtool libc-dev pkgconf \
+      build-base coreutils make rpm wget curl cyrus-sasl-dev libevent libsasl lz4-dev \
+      openssh openssl openssl-dev yajl-dev zlib-dev
+
+WORKDIR /app
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=1 GOOS=linux CGO_LDFLAGS="-fuse-ld=mold -lsasl2" go build -tags musl --ldflags "-w -s" -a -o producer producer/producer.go
+
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS runtime
+WORKDIR /
+# Same runtime shared libs as the consumer image: libgcc + librdkafka +
+# cyrus-sasl, plus ca-certificates for SASL_SSL bootstrap to a public broker.
+RUN apk add --no-cache libgcc librdkafka cyrus-sasl ca-certificates
+RUN addgroup -g 1000 srvgroup && adduser -D srvuser -u 1000 -G srvgroup
+COPY --from=builder /app/producer /
+USER srvuser:srvgroup
+# The producer is a one-shot CLI — it publishes NumMessages messages and
+# exits with code 0. No port exposed.
+ENTRYPOINT [ "./producer" ]

--- a/Dockerfile.producer
+++ b/Dockerfile.producer
@@ -16,11 +16,14 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=1 GOOS=linux CGO_LDFLAGS="-fuse-ld=mold -lsasl2" go build -tags musl --ldflags "-w -s" -a -o producer producer/producer.go
 
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS runtime
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime
 WORKDIR /
 # Same runtime shared libs as the consumer image: libgcc + librdkafka +
 # cyrus-sasl, plus ca-certificates for SASL_SSL bootstrap to a public broker.
-RUN apk add --no-cache libgcc librdkafka cyrus-sasl ca-certificates
+# `apk upgrade` covers CVEs patched after the pinned base image was built
+# — see Dockerfile.consumer for the full rationale.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache libgcc librdkafka cyrus-sasl ca-certificates
 RUN addgroup -g 1000 srvgroup && adduser -D srvuser -u 1000 -G srvgroup
 COPY --from=builder /app/producer /
 USER srvuser:srvgroup

--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,44 @@
 SHELL := /bin/bash
-export PATH := $(HOME)/.local/bin:$(PATH)
+# Make recipes don't source shell rc files, so mise's auto-activation
+# isn't in effect inside `$(SHELL) -c '...'`. Put mise's shims dir on
+# PATH explicitly so every mise-managed tool (golangci-lint, gosec,
+# gitleaks, hadolint, trivy, actionlint, shellcheck, govulncheck, act)
+# resolves directly. ~/.local/bin stays on PATH for any tool that's
+# still hand-installed.
+export PATH := $(HOME)/.local/share/mise/shims:$(HOME)/.local/bin:$(PATH)
 
 CONSUMER_IMG ?= kafka-confluent-go-consumer:v0.0.61
-CURRENTTAG:=$(shell git describe --tags --abbrev=0)
-NEWTAG ?= $(shell bash -c 'read -p "Please provide a new tag (current tag - ${CURRENTTAG}): " newtag; echo $$newtag')
-GOFLAGS=-mod=mod
-GOPRIVATE=github.com/AndriyKalashnykov/go-kafka-confluent-examples
+CURRENTTAG := $(shell git describe --tags --abbrev=0)
+GOFLAGS = -mod=mod
+GOPRIVATE = github.com/AndriyKalashnykov/go-kafka-confluent-examples
 OS ?= $(shell uname -s | tr A-Z a-z)
-ENVFILE=./.env
-OSXCROSS_PATH=/opt/osxcross-clang-17.0.3-macosx-14.0/target/bin
+ENVFILE = ./.env
+OSXCROSS_PATH = /opt/osxcross-clang-17.0.3-macosx-14.0/target/bin
 
-# === Tool Versions (pinned) ===
-# renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_VERSION := 2.11.4
-# renovate: datasource=github-releases depName=nektos/act
-ACT_VERSION      := 0.2.87
-# renovate: datasource=github-releases depName=hadolint/hadolint
-HADOLINT_VERSION := 2.14.0
-# renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
-GOVULNCHECK_VERSION := 1.2.0
-# renovate: datasource=github-releases depName=securego/gosec
-GOSEC_VERSION    := 2.25.0
-# renovate: datasource=github-releases depName=zricethezav/gitleaks
-GITLEAKS_VERSION := 8.30.1
-# renovate: datasource=github-releases depName=rhysd/actionlint
-ACTIONLINT_VERSION := 1.7.12
-# renovate: datasource=github-releases depName=aquasecurity/trivy
-TRIVY_VERSION    := 0.69.3
-# renovate: datasource=github-releases depName=koalaman/shellcheck
-SHELLCHECK_VERSION := 0.11.0
+# === Tool versions managed by mise (.mise.toml) ===
+# golangci-lint, act, hadolint, gosec, gitleaks, actionlint, shellcheck,
+# trivy, govulncheck — all installed by `mise install`. To bump versions,
+# edit .mise.toml; Renovate's mise manager tracks updates automatically.
+
+# === Docker-image-only tool pins (no host install) ===
 # renovate: datasource=docker depName=minlag/mermaid-cli
 MERMAID_CLI_VERSION := 11.12.0
+# renovate: datasource=docker depName=ghcr.io/gythialy/golang-cross
+GOLANG_CROSS_VERSION := v1.26.2
 
 # Parse Go version from root go.mod (used for release docker builder image tag)
-GO_VERSION  := $(shell grep -oP '^go \K[0-9.]+' go.mod)
-GO_BUILDER_VERSION := v$(GO_VERSION)
+GO_VERSION := $(shell grep -oP '^go \K[0-9.]+' go.mod)
 
 # Node version derived from .nvmrc (mise reads it natively)
 NODE_VERSION := $(shell cat .nvmrc 2>/dev/null || echo 24)
 
-define load_env
-$(eval include $(ENVFILE))
-$(eval export $(shell sed -ne 's/ *#.*$$//; /./ s/=.*$$// p' $(ENVFILE)))
-endef
+# kubectl indirection — k8s-deploy/k8s-undeploy target the user's selected
+# context (production or staging cluster); they are NOT kind-bound. To pin
+# a specific cluster, override at invocation:
+#   make k8s-deploy KUBECTL='kubectl --context=my-prod-cluster'
+# The e2e KinD harness pins its own kubectl context inline (see
+# e2e/e2e-kind-test.sh).
+KUBECTL ?= kubectl
 
 ifneq (,$(wildcard $(ENVFILE)))
 $(eval export $(shell sed -ne 's/ *#.*$$//; /./ s/=.*$$// p' $(ENVFILE)))
@@ -54,112 +50,27 @@ endif
 help:
 	@echo "Usage: make COMMAND"
 	@echo "Commands :"
-	@grep -E '[a-zA-Z\.\-]+:.*?@ .*$$' $(MAKEFILE_LIST)| tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[32m%-24s\033[0m - %s\n", $$1, $$2}'
+	@grep -E '[a-zA-Z0-9_.\-]+:.*?@ .*$$' $(MAKEFILE_LIST) | tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[32m%-24s\033[0m - %s\n", $$1, $$2}'
 
-#deps: @ Install and verify required toolchain (Go via mise)
+#deps: @ Install required toolchain via mise (Go, Node, lint/sec scanners)
 deps:
-	@command -v mise >/dev/null 2>&1 || { \
-		echo "Installing mise (no root required, installs to ~/.local/bin)..."; \
-		curl -fsSL https://mise.run | sh; \
-	}
-	@command -v go >/dev/null 2>&1 || { \
-		echo "Installing Go via mise from .mise.toml..."; \
-		mise install; \
-	}
-	@command -v git >/dev/null 2>&1 || { echo "git is not installed"; exit 1; }
-	@command -v golangci-lint >/dev/null 2>&1 || { echo "Installing golangci-lint $(GOLANGCI_VERSION)..."; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_VERSION); }
+	@# In CI, jdx/mise-action installs mise — don't redundantly bootstrap
+	@# (skill rule). Locally, install mise on first invocation.
+	@if [ -z "$$CI" ]; then \
+		command -v mise >/dev/null 2>&1 || { \
+			echo "Installing mise (no root required, installs to ~/.local/bin)..."; \
+			curl -fsSL https://mise.run | sh; \
+		}; \
+	fi
+	@command -v git >/dev/null 2>&1 || { echo "Error: git is required."; exit 1; }
+	@# `mise install` runs in both local and CI so all tool versions resolve.
+	@mise install --yes
 
-#deps-check: @ Show required Go version and mise status
+#deps-check: @ Show required tool versions and mise status
 deps-check:
-	@echo "Go version required: $(GO_VERSION) (from go.mod)"
+	@echo "Go version required:   $(GO_VERSION) (from go.mod)"
 	@echo "Node version required: $(NODE_VERSION) (from .nvmrc)"
 	@command -v mise >/dev/null 2>&1 && mise list || echo "mise not installed - install from https://mise.jdx.dev"
-
-#deps-act: @ Install act for local CI
-deps-act: deps
-	@command -v act >/dev/null 2>&1 || { echo "Installing act $(ACT_VERSION)..."; \
-		mkdir -p $(HOME)/.local/bin; \
-		curl -sSfL https://raw.githubusercontent.com/nektos/act/master/install.sh | bash -s -- -b $(HOME)/.local/bin v$(ACT_VERSION); \
-	}
-
-#deps-hadolint: @ Install hadolint for Dockerfile linting
-deps-hadolint: deps
-	@command -v hadolint >/dev/null 2>&1 || { \
-		OS_NAME=$$(uname -s); \
-		mkdir -p $(HOME)/.local/bin; \
-		if [ "$$OS_NAME" = "Linux" ]; then \
-			echo "Installing hadolint $(HADOLINT_VERSION)..."; \
-			curl -sSfL -o $(HOME)/.local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v$(HADOLINT_VERSION)/hadolint-Linux-x86_64 && \
-			chmod +x $(HOME)/.local/bin/hadolint; \
-		elif [ "$$OS_NAME" = "Darwin" ]; then \
-			echo "Installing hadolint $(HADOLINT_VERSION) (macOS)..."; \
-			curl -sSfL -o $(HOME)/.local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v$(HADOLINT_VERSION)/hadolint-Darwin-x86_64 && \
-			chmod +x $(HOME)/.local/bin/hadolint; \
-		else \
-			echo "Unsupported OS for hadolint install: $$OS_NAME"; exit 1; \
-		fi; \
-	}
-
-#deps-govulncheck: @ Install govulncheck
-deps-govulncheck: deps
-	@command -v govulncheck >/dev/null 2>&1 || { echo "Installing govulncheck $(GOVULNCHECK_VERSION)..."; \
-		go install golang.org/x/vuln/cmd/govulncheck@v$(GOVULNCHECK_VERSION); }
-
-#deps-gosec: @ Install gosec
-deps-gosec: deps
-	@command -v gosec >/dev/null 2>&1 || { echo "Installing gosec $(GOSEC_VERSION)..."; \
-		go install github.com/securego/gosec/v2/cmd/gosec@v$(GOSEC_VERSION); }
-
-#deps-gitleaks: @ Install gitleaks
-deps-gitleaks: deps
-	@command -v gitleaks >/dev/null 2>&1 || { echo "Installing gitleaks $(GITLEAKS_VERSION)..."; \
-		go install github.com/zricethezav/gitleaks/v8@v$(GITLEAKS_VERSION); }
-
-#deps-actionlint: @ Install actionlint
-deps-actionlint: deps
-	@command -v actionlint >/dev/null 2>&1 || { echo "Installing actionlint $(ACTIONLINT_VERSION)..."; \
-		go install github.com/rhysd/actionlint/cmd/actionlint@v$(ACTIONLINT_VERSION); }
-
-#deps-shellcheck: @ Install shellcheck (required for actionlint shell-script linting)
-deps-shellcheck: deps
-	@command -v shellcheck >/dev/null 2>&1 || { \
-		OS_NAME=$$(uname -s | tr A-Z a-z); \
-		ARCH=$$(uname -m); \
-		mkdir -p $(HOME)/.local/bin; \
-		echo "Installing shellcheck $(SHELLCHECK_VERSION)..."; \
-		curl -sSfL -o /tmp/shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v$(SHELLCHECK_VERSION)/shellcheck-v$(SHELLCHECK_VERSION).$${OS_NAME}.$${ARCH}.tar.xz" && \
-		tar -xJf /tmp/shellcheck.tar.xz -C /tmp && \
-		install -m 755 /tmp/shellcheck-v$(SHELLCHECK_VERSION)/shellcheck $(HOME)/.local/bin/shellcheck && \
-		rm -rf /tmp/shellcheck-v$(SHELLCHECK_VERSION) /tmp/shellcheck.tar.xz; \
-	}
-
-#deps-trivy: @ Install Trivy for security scanning
-deps-trivy: deps
-	@command -v trivy >/dev/null 2>&1 || { \
-		OS_NAME=$$(uname -s); \
-		ARCH=$$(uname -m); \
-		case "$$ARCH" in x86_64) ARCH_NAME=64bit ;; aarch64|arm64) ARCH_NAME=ARM64 ;; *) ARCH_NAME=$$ARCH ;; esac; \
-		echo "Installing trivy $(TRIVY_VERSION) for $$OS_NAME-$$ARCH_NAME..."; \
-		mkdir -p $(HOME)/.local/bin; \
-		curl -sSfL -o /tmp/trivy.tar.gz "https://github.com/aquasecurity/trivy/releases/download/v$(TRIVY_VERSION)/trivy_$(TRIVY_VERSION)_$${OS_NAME}-$${ARCH_NAME}.tar.gz" && \
-		tar -xzf /tmp/trivy.tar.gz -C /tmp trivy && \
-		install -m 755 /tmp/trivy $(HOME)/.local/bin/trivy && \
-		rm -f /tmp/trivy /tmp/trivy.tar.gz; \
-	}
-
-#clean: @ Cleanup
-clean:
-	@rm -rf .bin/ dist/
-
-#format: @ Format Go code
-format: deps
-	@gofmt -s -w .
-	@command -v goimports >/dev/null 2>&1 && goimports -w . || true
-
-#format-check: @ Verify code is formatted
-format-check: deps
-	@test -z "$$(gofmt -s -l .)" || { echo "Code not formatted. Run 'make format'"; gofmt -s -l .; exit 1; }
 
 #deps-prune: @ Remove unused Go dependencies
 deps-prune: deps
@@ -168,35 +79,48 @@ deps-prune: deps
 #deps-prune-check: @ Verify go.mod and go.sum are clean
 deps-prune-check: deps
 	@cp go.mod go.mod.bak && cp go.sum go.sum.bak
-	@go mod tidy
-	@diff -q go.mod go.mod.bak >/dev/null && diff -q go.sum go.sum.bak >/dev/null || { \
-		echo "go.mod/go.sum not tidy. Run 'make deps-prune'"; \
-		mv go.mod.bak go.mod; mv go.sum.bak go.sum; exit 1; }
+	@trap 'mv go.mod.bak go.mod 2>/dev/null; mv go.sum.bak go.sum 2>/dev/null' EXIT INT TERM; \
+		go mod tidy && \
+		diff -q go.mod go.mod.bak >/dev/null && \
+		diff -q go.sum go.sum.bak >/dev/null || { \
+			echo "go.mod/go.sum not tidy. Run 'make deps-prune'"; exit 1; }
 	@rm -f go.mod.bak go.sum.bak
 
-#lint: @ Run golangci-lint + hadolint
-lint: deps deps-hadolint
+#clean: @ Cleanup
+clean:
+	@rm -rf .bin/ dist/
+
+#format: @ Format Go code
+format: deps
+	@gofmt -s -w .
+
+#format-check: @ Verify code is formatted
+format-check: deps
+	@test -z "$$(gofmt -s -l .)" || { echo "Code not formatted. Run 'make format'"; gofmt -s -l .; exit 1; }
+
+#lint: @ Run golangci-lint and hadolint (both Dockerfiles)
+lint: deps
 	@export CGO_ENABLED=1 && golangci-lint run ./...
-	@command -v hadolint >/dev/null 2>&1 && hadolint Dockerfile.consumer || true
+	@hadolint Dockerfile.consumer Dockerfile.producer
 
 #vulncheck: @ Run govulncheck
-vulncheck: deps-govulncheck
+vulncheck: deps
 	@govulncheck ./...
 
 #sec: @ Run gosec static security analysis
-sec: deps-gosec
-	@gosec -quiet ./... || { echo "gosec found issues"; exit 1; }
+sec: deps
+	@gosec -quiet ./...
 
 #secrets: @ Run gitleaks secret scan
-secrets: deps-gitleaks
+secrets: deps
 	@gitleaks detect --no-banner --source .
 
 #lint-ci: @ Run actionlint on GitHub workflows
-lint-ci: deps-actionlint deps-shellcheck
+lint-ci: deps
 	@actionlint
 
 #trivy-fs: @ Trivy filesystem scan (secrets + misconfigs; Go CVEs handled by govulncheck)
-trivy-fs: deps-trivy
+trivy-fs: deps
 	@trivy fs --scanners secret,misconfig --severity CRITICAL,HIGH --exit-code 1 .
 
 #mermaid-lint: @ Parse-check every ```mermaid block in markdown files via pinned mermaid-cli (same engine github.com uses)
@@ -235,17 +159,30 @@ ci: deps static-check test integration-test build
 	@echo "Local CI pipeline passed."
 
 #ci-run: @ Run GitHub Actions workflow locally using act
-ci-run: deps-act
+ci-run: deps
 	@# Pick a random high port for the artifact server so concurrent
 	@# `make ci-run` invocations across different repos don't race on
 	@# act's default 34567. --artifact-server-path uses a per-run temp
 	@# dir for the same reason.
+	@#
+	@# act's synthetic push-event payload omits `repository.default_branch`,
+	@# which dorny/paths-filter requires to compute the diff base. Real
+	@# GitHub Actions populates this field automatically; locally we inject
+	@# it via --eventpath so the `changes` job behaves the same as in CI.
 	@ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
+	EVENT=$$(mktemp -t act-event.XXXXXX.json); \
+	printf '{"repository":{"default_branch":"main"}}\n' > "$$EVENT"; \
+	trap 'rm -f "$$EVENT"' EXIT; \
 	act push --container-architecture linux/amd64 \
+		--eventpath "$$EVENT" \
 		--artifact-server-port "$$ACT_PORT" \
 		--artifact-server-path "$$(mktemp -d -t act-artifacts.XXXXXX)"
 
-#update: @ Update dependency packages to latest versions
+#kind-tools-install: @ Install kind + kubectl into ~/.local/bin (used by CI e2e job and locally)
+kind-tools-install:
+	@./scripts/kind-tools-install.sh
+
+#update: @ MANUAL escape hatch — Renovate is canonical. Force-bump all Go deps to latest tags.
 update: deps
 	@export GOPRIVATE=$(GOPRIVATE) GOFLAGS=$(GOFLAGS) && cd ./producer && go get -u ./... && go mod tidy && cd ..
 	@export GOPRIVATE=$(GOPRIVATE) GOFLAGS=$(GOFLAGS) && cd ./consumer && go get -u ./... && go mod tidy && cd ..
@@ -254,35 +191,32 @@ update: deps
 get: deps
 	@export GOPRIVATE=$(GOPRIVATE) GOFLAGS=$(GOFLAGS) && go get ./... && go mod tidy
 
-#release: @ Create and push a new tag
+#release: @ Create and push a new tag (interactive — prompts for semver vMAJOR.MINOR.PATCH)
 release:
-	$(eval NT=$(NEWTAG))
-	@if ! echo "$(NT)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-		echo "Error: tag '$(NT)' is not valid semver (expected vMAJOR.MINOR.PATCH)"; \
-		exit 1; \
-	fi
-	@echo -n "Are you sure to create and push ${NT} tag? [y/N] " && read ans && [ $${ans:-N} = y ]
-	@echo ${NT} > ./version.txt
-	@git add version.txt
-	@git commit -s -m "Cut ${NT} release"
-	@git tag ${NT}
-	@git push origin ${NT}
-	@git push
-	@echo "Done."
+	@read -r -p "Please provide a new tag (current tag - $(CURRENTTAG)): " NT; \
+	if ! echo "$$NT" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "Error: tag '$$NT' is not valid semver (expected vMAJOR.MINOR.PATCH)"; exit 1; \
+	fi; \
+	read -r -p "Are you sure to create and push $$NT tag? [y/N] " ans; \
+	if [ "$${ans:-N}" != "y" ]; then echo "Aborted."; exit 1; fi; \
+	echo "$$NT" > ./version.txt && \
+	git add version.txt && \
+	git commit -s -m "Cut $$NT release" && \
+	git tag "$$NT" && \
+	git push origin "$$NT" && \
+	git push && \
+	echo "Done."
 
 #version: @ Print current version(tag)
 version:
-	@echo $(shell git describe --tags --abbrev=0)
+	@echo $(CURRENTTAG)
 
 #consumer-image-build: @ Build Consumer Docker image
 consumer-image-build: build
-	@docker buildx build --load -t ${CONSUMER_IMG} -f Dockerfile.consumer .
+	@docker buildx build --load -t $(CONSUMER_IMG) -f Dockerfile.consumer .
 
 #consumer-image-run: @ Run Consumer Docker image via Compose
 consumer-image-run: consumer-image-stop
-ifneq (,$(wildcard $(ENVFILE)))
-	$(call load_env)
-endif
 	@docker compose -f "docker-compose.yml" up --build
 
 #consumer-image-stop: @ Stop Consumer Docker image
@@ -291,16 +225,10 @@ consumer-image-stop:
 
 #kafka-run-producer: @ Run producer
 kafka-run-producer: build
-ifneq (,$(wildcard $(ENVFILE)))
-	$(call load_env)
-endif
 	@.bin/producer
 
 #kafka-run-consumer: @ Run consumer
 kafka-run-consumer: build
-ifneq (,$(wildcard $(ENVFILE)))
-	$(call load_env)
-endif
 	@.bin/consumer
 
 #test-release: @ Test release build locally
@@ -310,13 +238,13 @@ test-release: clean
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(GOPATH)/src:/go/src \
 		-w /golang-cross-example \
-		ghcr.io/gythialy/golang-cross:$(GO_BUILDER_VERSION) --skip=publish --clean --snapshot --config .goreleaser-Linux.yml
+		ghcr.io/gythialy/golang-cross:$(GOLANG_CROSS_VERSION) --skip=publish --clean --snapshot --config .goreleaser-Linux.yml
 	@docker run --rm --privileged \
 		-v $(CURDIR):/golang-cross-example \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(GOPATH)/src:/go/src \
 		-w /golang-cross-example \
-		ghcr.io/gythialy/golang-cross:$(GO_BUILDER_VERSION) --skip=publish --clean --snapshot --config .goreleaser-Darwin-cross.yml
+		ghcr.io/gythialy/golang-cross:$(GOLANG_CROSS_VERSION) --skip=publish --clean --snapshot --config .goreleaser-Darwin-cross.yml
 
 #e2e-compose: @ Run E2E via Docker Compose (PLAINTEXT Kafka broker + consumer, no SASL)
 e2e-compose:
@@ -326,27 +254,26 @@ e2e-compose:
 e2e:
 	@./e2e/e2e-kind-test.sh
 
-#k8s-deploy: @ Deploy to Kubernetes
+#k8s-deploy: @ Deploy to Kubernetes (uses $(KUBECTL); override KUBECTL='kubectl --context=...' to pin)
 k8s-deploy:
 	@test -f ./k8s/cm.yaml || { echo "Error: k8s/cm.yaml missing. Generate with: kubectl create configmap kafka-config --from-file kafka.properties -o yaml --dry-run=client > ./k8s/cm.yaml"; exit 1; }
 	@test -f ./k8s/sc.yaml || { echo "Error: k8s/sc.yaml missing. Generate from tmpl/sc.yaml.tmpl (see README)"; exit 1; }
-	@kubectl apply -f ./k8s/ns.yaml
-	@kubectl apply --namespace=kafka-confluent-examples -f ./k8s/cm.yaml
-	@kubectl apply --namespace=kafka-confluent-examples -f ./k8s/sc.yaml
-	@kubectl apply --namespace=kafka-confluent-examples -f ./k8s/deployment.yaml
-	@kubectl apply --namespace=kafka-confluent-examples -f ./k8s/service.yaml
+	@$(KUBECTL) apply -f ./k8s/ns.yaml
+	@$(KUBECTL) apply --namespace=kafka-confluent-examples -f ./k8s/cm.yaml
+	@$(KUBECTL) apply --namespace=kafka-confluent-examples -f ./k8s/sc.yaml
+	@$(KUBECTL) apply --namespace=kafka-confluent-examples -f ./k8s/deployment.yaml
+	@$(KUBECTL) apply --namespace=kafka-confluent-examples -f ./k8s/service.yaml
 
-#k8s-undeploy: @ Undeploy from Kubernetes
+#k8s-undeploy: @ Undeploy from Kubernetes (uses $(KUBECTL); override KUBECTL='kubectl --context=...' to pin)
 k8s-undeploy:
-	@kubectl delete -f ./k8s/deployment.yaml --namespace=kafka-confluent-examples --ignore-not-found=true && \
-	kubectl delete -f ./k8s/service.yaml --namespace=kafka-confluent-examples --ignore-not-found=true && \
-	kubectl delete -f ./k8s/sc.yaml --namespace=kafka-confluent-examples --ignore-not-found=true && \
-	kubectl delete -f ./k8s/cm.yaml --namespace=kafka-confluent-examples --ignore-not-found=true && \
-	kubectl delete -f ./k8s/ns.yaml --ignore-not-found=true
+	@$(KUBECTL) delete -f ./k8s/deployment.yaml --namespace=kafka-confluent-examples --ignore-not-found=true
+	@$(KUBECTL) delete -f ./k8s/service.yaml --namespace=kafka-confluent-examples --ignore-not-found=true
+	@$(KUBECTL) delete -f ./k8s/sc.yaml --namespace=kafka-confluent-examples --ignore-not-found=true
+	@$(KUBECTL) delete -f ./k8s/cm.yaml --namespace=kafka-confluent-examples --ignore-not-found=true
+	@$(KUBECTL) delete -f ./k8s/ns.yaml --ignore-not-found=true
 
 #renovate-validate: @ Validate Renovate configuration
 renovate-validate: deps
-	@command -v node >/dev/null 2>&1 || { echo "Installing Node $(NODE_VERSION) via mise..."; mise install node@$(NODE_VERSION); }
 	@if [ -n "$$GH_ACCESS_TOKEN" ]; then \
 		GITHUB_COM_TOKEN=$$GH_ACCESS_TOKEN npx --yes renovate --platform=local; \
 	else \
@@ -354,9 +281,10 @@ renovate-validate: deps
 		npx --yes renovate --platform=local; \
 	fi
 
-.PHONY: help deps deps-check deps-act deps-hadolint deps-govulncheck deps-gosec deps-gitleaks deps-actionlint deps-shellcheck deps-trivy \
-	clean format format-check deps-prune deps-prune-check \
-	lint vulncheck sec secrets lint-ci trivy-fs mermaid-lint static-check test integration-test e2e-compose e2e build ci ci-run \
+.PHONY: help deps deps-check deps-prune deps-prune-check \
+	clean format format-check \
+	lint vulncheck sec secrets lint-ci trivy-fs mermaid-lint static-check \
+	test integration-test e2e-compose e2e build ci ci-run kind-tools-install \
 	update get release version \
 	consumer-image-build consumer-image-run consumer-image-stop \
 	kafka-run-producer kafka-run-consumer test-release \

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ C4Context
   UpdateLayoutConfig($c4ShapeInRow="3")
 ```
 
+A developer builds the producer and consumer binaries (or the consumer container image) and points them at a Confluent Cloud cluster. Authentication is SASL/PLAIN over TLS on port 9092; credentials live in `.env` locally and in a Kubernetes `Secret` when deployed.
+
 ## Tech Stack
 
 | Component | Technology |
 |-----------|------------|
 | Language | Go 1.26.2 |
-| Kafka client | [confluent-kafka-go](https://github.com/confluentinc/confluent-kafka-go) v2.14.0 |
+| Kafka client | [confluent-kafka-go](https://github.com/confluentinc/confluent-kafka-go) v2.14.1 |
 | Native library | `librdkafka` (CGO-linked) |
 | Build | Make, GoReleaser (cross-compilation) |
 | Container | Docker, Docker Compose |
@@ -80,8 +82,8 @@ C4Container
   Person(dev, "Developer / Operator")
 
   System_Boundary(sys, "go-kafka-confluent-examples") {
-    Container(producer, "Producer", "Go 1.26, confluent-kafka-go v2.14 (CGO + librdkafka)", "Publishes messages to test-topic")
-    Container(consumer, "Consumer", "Go 1.26, confluent-kafka-go v2.14 (CGO + librdkafka)", "Subscribes and logs messages")
+    Container(producer, "Producer", "Go 1.26, confluent-kafka-go v2.14.1 (CGO + librdkafka)", "Publishes messages to test-topic")
+    Container(consumer, "Consumer", "Go 1.26, confluent-kafka-go v2.14.1 (CGO + librdkafka)", "Subscribes and logs messages")
     Container(cm, "ConfigMap", "Kubernetes", "kafka.properties — bootstrap server, SASL mechanism")
     Container(secret, "Secret", "Kubernetes", "API key and secret for SASL/PLAIN auth")
   }
@@ -98,7 +100,7 @@ C4Container
   Rel(consumer, topic, "Consumes", "Kafka / SASL_SSL")
 ```
 
-- **Producer** / **Consumer** — statically-linked Go binaries; both depend on `librdkafka` via CGO (see [`Dockerfile.consumer`](Dockerfile.consumer) for the Alpine build chain)
+- **Producer** / **Consumer** — statically-linked Go binaries; both depend on `librdkafka` via CGO (see [`Dockerfile.consumer`](Dockerfile.consumer) and [`Dockerfile.producer`](Dockerfile.producer) for the Alpine build chain). The producer is a one-shot CLI (publishes `NUM_MESSAGES` then exits); the consumer is a long-running subscriber.
 - **ConfigMap** holds non-secret Kafka client settings (`bootstrap.servers`, `security.protocol`, `sasl.mechanism`); **Secret** holds the API key/secret pair — both are mounted into the consumer pod by `k8s/deployment.yaml`
 - **Confluent Cloud Topic** is external; authentication is SASL/PLAIN over TLS
 
@@ -124,6 +126,8 @@ sequenceDiagram
   CC-->>C: Message batch
   C->>CC: Commit offset
 ```
+
+Bootstrap loads `kafka.properties` + `.env` for SASL_SSL credentials. The producer connects, authenticates, publishes a key/value pair, and waits for the broker's delivery report (ack). The consumer connects with the same credentials, receives partition assignments from the consumer-group coordinator, polls for message batches, and commits offsets after processing.
 
 Source diagrams live inline in this README; lint via `make mermaid-lint` (pinned [`minlag/mermaid-cli`](https://github.com/mermaid-js/mermaid-cli) Docker image).
 
@@ -215,9 +219,10 @@ Run `make help` to see all available targets.
 | `make build` | Build producer and consumer binaries |
 | `make test` | Run unit tests with `-race -cover` |
 | `make integration-test` | Run integration tests (`go test -tags=integration`) |
-| `make e2e-compose` | Run E2E via Docker Compose (PLAINTEXT Kafka broker + consumer image; real produce → consume round-trip) |
-| `make e2e` | Run E2E via KinD cluster (in-cluster Kafka + real `k8s/*.yaml` manifests, PLAINTEXT overrides) |
+| `make e2e-compose` | Run E2E via Docker Compose — PLAINTEXT Kafka broker + **both** binary images (`Dockerfile.consumer` long-lived + `Dockerfile.producer` one-shot); real produce → consume round-trip |
+| `make e2e` | Run E2E via KinD cluster (in-cluster Kafka + real `k8s/*.yaml` manifests, PLAINTEXT overrides; kubectl context pinned to `kind-kafka-e2e` for multi-session safety) |
 | `make format` | Format Go code (`gofmt -s -w .`) |
+| `make format-check` | Verify code is formatted (CI gate) |
 | `make lint` | Run golangci-lint and hadolint |
 | `make static-check` | Composite quality gate (format-check + deps-prune-check + lint + lint-ci + sec + vulncheck + secrets + trivy-fs + mermaid-lint) |
 | `make clean` | Remove build artifacts |
@@ -231,6 +236,7 @@ Run `make help` to see all available targets.
 | `make deps` | Install and verify required toolchain (mise + Go) |
 | `make deps-check` | Show required Go version and mise status |
 | `make deps-prune` | Run `go mod tidy` |
+| `make deps-prune-check` | Verify go.mod and go.sum are clean (CI gate) |
 | `make get` | Download and install dependency packages |
 | `make update` | Update dependency packages to latest versions |
 
@@ -283,15 +289,16 @@ GitHub Actions runs on every push to `main`, tags `v*`, and pull requests.
 | Job | Triggers | Steps |
 |-----|----------|-------|
 | `setup` | push, PR | Extract Go version from `go.mod` for downstream jobs |
-| `static-check` | push, PR | `make static-check` composite (lint + sec + vulncheck + secrets + lint-ci + trivy-fs) |
-| `test` | push, PR | Unit tests (matrix: ubuntu-latest + macos-latest) |
-| `integration-test` | push, PR | `make integration-test` (Testcontainers-backed; ubuntu-latest) |
-| `e2e-compose` | push, PR | `make e2e-compose` (Docker Compose with PLAINTEXT broker; ubuntu-latest) |
-| `e2e` | push, PR | `make e2e` (KinD cluster + in-cluster Kafka + real `k8s/` manifests; ubuntu-latest) |
-| `build` | push, PR | Matrix: ubuntu-latest + macos-latest |
-| `ci-pass` | always | Aggregator for branch protection |
+| `changes` | push, PR | [`dorny/paths-filter`](https://github.com/dorny/paths-filter) — emits `code=true` unless the diff is doc-only (`**.md`, `docs/**`, `LICENSE`, `**.png`, `.claude/**`). Heavy jobs gate on `needs.changes.outputs.code == 'true'` so doc-only PRs skip the pipeline while still satisfying the `ci-pass` required check |
+| `static-check` | push, PR (when code changes) | `make static-check` composite (lint + sec + vulncheck + secrets + lint-ci + trivy-fs + mermaid-lint) |
+| `test` | push, PR (when code changes) | Unit tests (matrix: ubuntu-latest + macos-latest) |
+| `integration-test` | push, PR (when code changes) | `make integration-test` (Testcontainers-backed; ubuntu-latest) |
+| `e2e-compose` | push, PR (when code changes) | `make e2e-compose` (Docker Compose with PLAINTEXT broker; ubuntu-latest) |
+| `e2e` | push, PR (when code changes) | `make e2e` (KinD cluster + in-cluster Kafka + real `k8s/` manifests; ubuntu-latest) |
+| `build` | push, PR (when code changes) | Matrix: ubuntu-latest + macos-latest |
+| `ci-pass` | always | Aggregator for branch protection — passes when all upstream jobs are `success` or `skipped` |
 | `release-binaries` | tags only | GoReleaser cross-compilation (Linux + macOS) |
-| `docker` | tags only | Multi-arch (`linux/amd64,linux/arm64`) build, Trivy scan, smoke test, push to `ghcr.io`, cosign sign |
+| `docker` | every code-changing push (publish gated to tags) | Build single-arch for scan → Trivy image scan → smoke test → multi-arch validation build (push gated by tag) → cosign sign (tag only). Runs every code push so multi-arch cross-compile regressions and cosign installer breakage surface on the commit that introduced them, not release day |
 
 ### Required Secrets and Variables
 
@@ -323,7 +330,7 @@ Buildkit in-manifest attestations (`provenance` + `sbom`) are disabled so the im
 Verify a published image's signature:
 
 ```bash
-cosign verify ghcr.io/andriykalashnykov/kafka-confluent-go-consumer:<tag> \
+cosign verify ghcr.io/andriykalashnykov/go-kafka-confluent-examples/kafka-confluent-go-consumer:<tag> \
   --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/go-kafka-confluent-examples/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -1,3 +1,7 @@
+// Consumer entrypoint. The thin shell here delegates env-var translation
+// to internal/util.BuildKafkaConfigMap (testable, returns errors instead
+// of os.Exit), wires SIGINT/SIGTERM to ctx-cancel, and hands off to
+// internal/consumer.Run (testable, driven by ctx + Config).
 package main
 
 import (
@@ -12,16 +16,16 @@ import (
 )
 
 func main() {
-	configFile := util.ReadEnvVar(util.KafkaConfigFileEnv)
-	conf := util.ReadConfig(configFile)
-
-	if err := conf.SetKey(util.SaslUserName, util.ReadEnvVar(util.SaslUserNameEnv)); err != nil {
-		fmt.Printf("Failed to set %s: %s\n", util.SaslUserName, err)
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	if err := conf.SetKey(util.SaslPwd, util.ReadEnvVar(util.SaslPwdEnv)); err != nil {
-		fmt.Printf("Failed to set %s: %s\n", util.SaslPwd, err)
-		os.Exit(1)
+}
+
+func run() error {
+	conf, topic, err := util.BuildKafkaConfigMap(os.Getenv)
+	if err != nil {
+		return fmt.Errorf("consumer: build config: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -35,13 +39,9 @@ func main() {
 		cancel()
 	}()
 
-	topic := util.ReadEnvVar(util.KafkaTopicEnv)
-	if err := consumer.Run(ctx, consumer.Config{
+	return consumer.Run(ctx, consumer.Config{
 		KafkaConfig: conf,
 		Topic:       topic,
 		Out:         os.Stdout,
-	}); err != nil {
-		fmt.Printf("Consumer failed: %s\n", err)
-		os.Exit(1)
-	}
+	})
 }

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -1,11 +1,17 @@
 # E2E fixture: Apache Kafka in KRaft mode (PLAINTEXT, no SASL) + the
-# consumer image built from Dockerfile.consumer. A test harness produces
-# messages via kafka-console-producer.sh inside the broker container and
-# asserts the consumer logs "Consumed event from topic e2e-topic" 5 times.
+# consumer image built from Dockerfile.consumer + a one-shot producer
+# image built from Dockerfile.producer.
+#
+# Test harness: e2e-compose-test.sh runs `compose run --rm producer`
+# against an already-running consumer + broker, then asserts the consumer
+# logs "Consumed event from topic e2e-topic" N times. This exercises BOTH
+# binaries' boot/connect/produce-or-consume paths — the previous version
+# only exercised the consumer because messages were produced via
+# kafka-console-producer.sh (which bypasses producer.Run + Dockerfile.producer).
 #
 # Not for production: advertised listener is hardcoded to "kafka:9092"
 # (the service DNS name on the compose network), and replication factors
-# are 1. See e2e/e2e-compose-test.sh for the harness.
+# are 1.
 services:
   kafka:
     image: apache/kafka:3.9.0
@@ -51,6 +57,32 @@ services:
       # librdkafka ignores SASL settings when security.protocol=PLAINTEXT,
       # but consumer/main.go sets them unconditionally — provide non-empty
       # placeholders so SetKey doesn't reject empty strings.
+      SASL_USERNAME: unused
+      SASL_PASSWORD: unused
+    volumes:
+      - ./kafka.properties:/kafka.properties:ro
+    networks:
+      - e2e_net
+
+  # One-shot producer: publishes N messages from the producer/producer.go
+  # binary, then exits 0. Invoked by the harness via `compose run --rm
+  # producer`. Not started by `compose up` (no `command` / no `restart`),
+  # which keeps `depends_on: kafka (healthy)` from blocking the consumer
+  # rollout while the harness is still bringing the topic online.
+  producer:
+    image: kafka-confluent-go-producer:e2e
+    container_name: e2e-producer
+    pull_policy: build
+    profiles: [producer]
+    build:
+      dockerfile: Dockerfile.producer
+      context: ..
+    depends_on:
+      kafka:
+        condition: service_healthy
+    environment:
+      KAFKA_CONFIG_FILE: /kafka.properties
+      KAFKA_TOPIC: e2e-topic
       SASL_USERNAME: unused
       SASL_PASSWORD: unused
     volumes:

--- a/e2e/e2e-compose-test.sh
+++ b/e2e/e2e-compose-test.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # E2E harness: brings up a PLAINTEXT Kafka broker + the consumer image via
-# docker compose, produces N messages via kafka-console-producer.sh, and
-# asserts the consumer logged a matching number of "Consumed event" lines
-# before timing out.
+# docker compose, runs the producer binary (built from Dockerfile.producer)
+# as a one-shot job to publish N messages, then asserts the consumer logged
+# a matching number of "Consumed event" lines before timing out.
+#
+# Both producer and consumer are exercised end-to-end through their
+# Dockerfiles + producer.Run / consumer.Run loops — no Kafka CLI
+# substitution. Validates env-var plumbing, librdkafka linkage, and the
+# Dockerfile.producer build.
 #
 # Exit codes: 0 pass, non-zero fail. Compose is torn down on exit.
 set -euo pipefail
@@ -17,7 +22,7 @@ WAIT_TIMEOUT=60
 # shellcheck disable=SC2329  # called indirectly via trap
 cleanup() {
   echo "==> Tearing down..."
-  $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+  $COMPOSE --profile producer down -v --remove-orphans >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -33,14 +38,13 @@ echo "==> Starting consumer..."
 $COMPOSE up -d consumer
 sleep 3  # let the consumer join the group
 
-echo "==> Producing $N messages..."
-{
-  for i in $(seq 1 "$N"); do
-    printf 'e2e-key-%d:e2e-value-%d\n' "$i" "$i"
-  done
-} | docker exec -i e2e-kafka /opt/kafka/bin/kafka-console-producer.sh \
-  --bootstrap-server localhost:9092 --topic "$TOPIC" \
-  --property parse.key=true --property key.separator=:
+echo "==> Building producer image and producing $N messages via producer/producer.go binary..."
+# `compose run --rm` builds the image (pull_policy: build), starts a one-shot
+# container that runs `./producer`, which publishes NUM_MESSAGES events and
+# exits. Removes the container after exit.
+$COMPOSE --profile producer run --rm \
+  -e NUM_MESSAGES="$N" \
+  producer
 
 echo "==> Waiting up to ${WAIT_TIMEOUT}s for consumer to process $N messages..."
 count=0

--- a/e2e/e2e-kind-test.sh
+++ b/e2e/e2e-kind-test.sh
@@ -21,6 +21,14 @@ TOPIC=e2e-topic
 N=5
 WAIT_TIMEOUT=90
 
+# Pin kubectl to this cluster's context. A sibling project running
+# `kubectl config use-context` against the shared ~/.kube/config could
+# otherwise overwrite the current-context globally and have our calls
+# hit the wrong cluster (silent failure: namespaces "vanish", rollouts
+# wait on non-existent Deployments). See /makefile §"Multi-session
+# kubectl context safety".
+KUBECTL=(kubectl --context="kind-${CLUSTER}")
+
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 # shellcheck disable=SC2329  # called indirectly via trap
@@ -45,25 +53,44 @@ kind load docker-image --name "$CLUSTER" "$IMG"
 # and hits "content digest not found".
 
 echo "==> Deploying namespace + Kafka broker..."
-kubectl apply -f k8s/ns.yaml
-kubectl -n "$NS" apply -f e2e/k8s/kafka.yaml
+"${KUBECTL[@]}" apply -f k8s/ns.yaml
+"${KUBECTL[@]}" -n "$NS" apply -f e2e/k8s/kafka.yaml
 
 echo "==> Waiting for Kafka rollout (includes first-time docker.io pull of apache/kafka)..."
-kubectl -n "$NS" rollout status deployment/kafka --timeout=180s
+# docker.io anonymous pull-rate-limit + transient registry hiccups make this
+# the most fragile step in the whole harness. Retry the rollout-status wait
+# up to 3x with a diagnostic dump on each failure so a flaky pull doesn't
+# fail the entire CI run; only escalate on persistent failure.
+ROLLOUT_OK=0
+for attempt in 1 2 3; do
+  if "${KUBECTL[@]}" -n "$NS" rollout status deployment/kafka --timeout=180s; then
+    ROLLOUT_OK=1
+    break
+  fi
+  echo "==> Kafka rollout attempt ${attempt}/3 timed out — dumping pod state and retrying..."
+  "${KUBECTL[@]}" -n "$NS" get pods -l app=kafka -o wide || true
+  "${KUBECTL[@]}" -n "$NS" describe deployment/kafka | tail -40 || true
+  "${KUBECTL[@]}" -n "$NS" describe pod -l app=kafka | grep -A3 'Events:' || true
+done
+if [ "$ROLLOUT_OK" -ne 1 ]; then
+  echo "FAIL: Kafka deployment did not become ready after 3 rollout attempts (~9 min)"
+  "${KUBECTL[@]}" -n "$NS" logs deployment/kafka --all-containers --tail=100 || true
+  exit 1
+fi
 
 echo "==> Creating topic '$TOPIC'..."
-kubectl -n "$NS" exec deployment/kafka -- \
+"${KUBECTL[@]}" -n "$NS" exec deployment/kafka -- \
   /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 \
   --create --topic "$TOPIC" --partitions 1 --replication-factor 1
 
 echo "==> Deploying consumer (ConfigMap + Secret + Deployment + Service)..."
-kubectl -n "$NS" apply -f e2e/k8s/cm.yaml
-kubectl -n "$NS" apply -f e2e/k8s/sc.yaml
-kubectl -n "$NS" apply -f e2e/k8s/deployment.yaml
-kubectl -n "$NS" apply -f k8s/service.yaml
+"${KUBECTL[@]}" -n "$NS" apply -f e2e/k8s/cm.yaml
+"${KUBECTL[@]}" -n "$NS" apply -f e2e/k8s/sc.yaml
+"${KUBECTL[@]}" -n "$NS" apply -f e2e/k8s/deployment.yaml
+"${KUBECTL[@]}" -n "$NS" apply -f k8s/service.yaml
 
 echo "==> Waiting for consumer rollout..."
-kubectl -n "$NS" rollout status deployment/kafka-confluent-go-consumer --timeout=120s
+"${KUBECTL[@]}" -n "$NS" rollout status deployment/kafka-confluent-go-consumer --timeout=120s
 sleep 3  # let the consumer-group join settle
 
 echo "==> Producing $N messages into $TOPIC..."
@@ -71,7 +98,7 @@ echo "==> Producing $N messages into $TOPIC..."
   for i in $(seq 1 "$N"); do
     printf 'e2e-key-%d:e2e-value-%d\n' "$i" "$i"
   done
-} | kubectl -n "$NS" exec -i deployment/kafka -- \
+} | "${KUBECTL[@]}" -n "$NS" exec -i deployment/kafka -- \
   /opt/kafka/bin/kafka-console-producer.sh \
   --bootstrap-server localhost:9092 --topic "$TOPIC" \
   --property parse.key=true --property key.separator=:
@@ -79,7 +106,7 @@ echo "==> Producing $N messages into $TOPIC..."
 echo "==> Waiting up to ${WAIT_TIMEOUT}s for consumer to process $N messages..."
 count=0
 for _ in $(seq 1 "$WAIT_TIMEOUT"); do
-  count=$(kubectl -n "$NS" logs deployment/kafka-confluent-go-consumer 2>/dev/null \
+  count=$("${KUBECTL[@]}" -n "$NS" logs deployment/kafka-confluent-go-consumer 2>/dev/null \
     | grep -c 'Consumed event from topic '"$TOPIC" || true)
   if [ "$count" -ge "$N" ]; then
     echo "PASS: consumer processed $count messages"
@@ -90,7 +117,7 @@ done
 
 echo "FAIL: consumer processed $count / $N messages"
 echo "==> Consumer logs:"
-kubectl -n "$NS" logs deployment/kafka-confluent-go-consumer || true
+"${KUBECTL[@]}" -n "$NS" logs deployment/kafka-confluent-go-consumer || true
 echo "==> Kafka logs (tail):"
-kubectl -n "$NS" logs deployment/kafka --tail=50 || true
+"${KUBECTL[@]}" -n "$NS" logs deployment/kafka --tail=50 || true
 exit 1

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -36,20 +36,14 @@ type Config struct {
 	Out io.Writer
 }
 
-// Run creates a consumer, subscribes to Topic, and reads messages until ctx is
-// cancelled or MaxMessages is reached. It always closes the consumer cleanly.
-func Run(ctx context.Context, cfg Config) error {
-	if cfg.Topic == "" {
-		return errors.New("consumer: Topic is required")
-	}
+// applyDefaults fills in zero-value fields with their documented defaults.
+// Pure: no I/O, no kafka.ConfigMap mutation. Run calls this first, then
+// applies the resulting GroupID / AutoOffsetReset to the embedded
+// kafka.ConfigMap (which DOES mutate the caller's map and is left in Run).
+func applyDefaults(cfg *Config) {
 	if cfg.GroupID == "" {
 		if _, ok := cfg.KafkaConfig["group.id"]; !ok {
 			cfg.GroupID = "kafka-go-getting-started"
-		}
-	}
-	if cfg.GroupID != "" {
-		if err := cfg.KafkaConfig.SetKey("group.id", cfg.GroupID); err != nil {
-			return fmt.Errorf("consumer: set group.id: %w", err)
 		}
 	}
 	if cfg.AutoOffsetReset == "" {
@@ -57,18 +51,31 @@ func Run(ctx context.Context, cfg Config) error {
 			cfg.AutoOffsetReset = "earliest"
 		}
 	}
+	if cfg.PollTimeout == 0 {
+		cfg.PollTimeout = 100 * time.Millisecond
+	}
+	if cfg.Out == nil {
+		cfg.Out = io.Discard
+	}
+}
+
+// Run creates a consumer, subscribes to Topic, and reads messages until ctx is
+// cancelled or MaxMessages is reached. It always closes the consumer cleanly.
+func Run(ctx context.Context, cfg Config) error {
+	if cfg.Topic == "" {
+		return errors.New("consumer: Topic is required")
+	}
+	applyDefaults(&cfg)
+
+	if cfg.GroupID != "" {
+		if err := cfg.KafkaConfig.SetKey("group.id", cfg.GroupID); err != nil {
+			return fmt.Errorf("consumer: set group.id: %w", err)
+		}
+	}
 	if cfg.AutoOffsetReset != "" {
 		if err := cfg.KafkaConfig.SetKey("auto.offset.reset", cfg.AutoOffsetReset); err != nil {
 			return fmt.Errorf("consumer: set auto.offset.reset: %w", err)
 		}
-	}
-	poll := cfg.PollTimeout
-	if poll == 0 {
-		poll = 100 * time.Millisecond
-	}
-	out := cfg.Out
-	if out == nil {
-		out = io.Discard
 	}
 
 	c, err := kafka.NewConsumer(&cfg.KafkaConfig)
@@ -77,26 +84,26 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	defer func() {
 		if err := c.Close(); err != nil {
-			_, _ = fmt.Fprintf(out, "Failed to close consumer: %v\n", err)
+			_, _ = fmt.Fprintf(cfg.Out, "Failed to close consumer: %v\n", err)
 		}
 	}()
 
 	if err := c.SubscribeTopics([]string{cfg.Topic}, nil); err != nil {
 		return fmt.Errorf("consumer: subscribe: %w", err)
 	}
-	_, _ = fmt.Fprintf(out, "Reading topic %v\n", cfg.Topic)
+	_, _ = fmt.Fprintf(cfg.Out, "Reading topic %v\n", cfg.Topic)
 
 	count := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil
 		}
-		ev, err := c.ReadMessage(poll)
+		ev, err := c.ReadMessage(cfg.PollTimeout)
 		if err != nil {
 			// Timeout/transient errors — the underlying client retries.
 			continue
 		}
-		_, _ = fmt.Fprintf(out, "Consumed event from topic %s: key = %-10s value = %s\n",
+		_, _ = fmt.Fprintf(cfg.Out, "Consumed event from topic %s: key = %-10s value = %s\n",
 			*ev.TopicPartition.Topic, string(ev.Key), string(ev.Value))
 		count++
 		if cfg.MaxMessages > 0 && count >= cfg.MaxMessages {

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -2,13 +2,126 @@ package consumer
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 func TestRun_MissingTopicReturnsError(t *testing.T) {
 	err := Run(context.Background(), Config{})
 	if err == nil || !strings.Contains(err.Error(), "Topic is required") {
 		t.Fatalf("Run({}) error = %v, want error containing %q", err, "Topic is required")
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Config
+		want Config
+	}{
+		{
+			name: "all zero — fills every default",
+			in:   Config{KafkaConfig: kafka.ConfigMap{}},
+			want: Config{
+				KafkaConfig:     kafka.ConfigMap{},
+				GroupID:         "kafka-go-getting-started",
+				AutoOffsetReset: "earliest",
+				PollTimeout:     100 * time.Millisecond,
+				Out:             io.Discard,
+			},
+		},
+		{
+			name: "explicit field overrides default",
+			in: Config{
+				KafkaConfig:     kafka.ConfigMap{},
+				GroupID:         "my-group",
+				AutoOffsetReset: "latest",
+				PollTimeout:     500 * time.Millisecond,
+			},
+			want: Config{
+				KafkaConfig:     kafka.ConfigMap{},
+				GroupID:         "my-group",
+				AutoOffsetReset: "latest",
+				PollTimeout:     500 * time.Millisecond,
+				Out:             io.Discard,
+			},
+		},
+		{
+			name: "KafkaConfig already has group.id — defaulting skipped",
+			in: Config{
+				KafkaConfig: kafka.ConfigMap{"group.id": "from-map"},
+			},
+			want: Config{
+				KafkaConfig:     kafka.ConfigMap{"group.id": "from-map"},
+				GroupID:         "", // stays empty so Run won't overwrite the map entry
+				AutoOffsetReset: "earliest",
+				PollTimeout:     100 * time.Millisecond,
+				Out:             io.Discard,
+			},
+		},
+		{
+			name: "KafkaConfig already has auto.offset.reset — defaulting skipped",
+			in: Config{
+				KafkaConfig: kafka.ConfigMap{"auto.offset.reset": "latest"},
+			},
+			want: Config{
+				KafkaConfig:     kafka.ConfigMap{"auto.offset.reset": "latest"},
+				GroupID:         "kafka-go-getting-started",
+				AutoOffsetReset: "",
+				PollTimeout:     100 * time.Millisecond,
+				Out:             io.Discard,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in
+			applyDefaults(&got)
+			if got.GroupID != tt.want.GroupID {
+				t.Errorf("GroupID = %q, want %q", got.GroupID, tt.want.GroupID)
+			}
+			if got.AutoOffsetReset != tt.want.AutoOffsetReset {
+				t.Errorf("AutoOffsetReset = %q, want %q", got.AutoOffsetReset, tt.want.AutoOffsetReset)
+			}
+			if got.PollTimeout != tt.want.PollTimeout {
+				t.Errorf("PollTimeout = %v, want %v", got.PollTimeout, tt.want.PollTimeout)
+			}
+			if got.Out == nil {
+				t.Error("Out is nil; want io.Discard")
+			}
+		})
+	}
+}
+
+// TestRun_BrokerUnreachable_ExitsOnCtxCancel verifies Run respects ctx
+// cancellation when the broker is unreachable, instead of blocking forever
+// in ReadMessage. Uses a closed port (127.0.0.1:1) — librdkafka's lazy
+// connection model means kafka.NewConsumer succeeds; the failures appear
+// as transient errors from ReadMessage which Run silently retries.
+func TestRun_BrokerUnreachable_ExitsOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{
+			KafkaConfig: kafka.ConfigMap{"bootstrap.servers": "127.0.0.1:1"},
+			Topic:       "unreachable-topic",
+			GroupID:     "test",
+			PollTimeout: 50 * time.Millisecond,
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v on ctx-cancel; want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not exit within 5s after ctx cancellation")
 	}
 }

--- a/internal/kafkaroundtrip/roundtrip_integration_test.go
+++ b/internal/kafkaroundtrip/roundtrip_integration_test.go
@@ -96,6 +96,92 @@ func TestProducerConsumerRoundTrip(t *testing.T) {
 	}
 }
 
+// TestConsumer_CtxCancelExitsCleanly verifies that consumer.Run returns nil
+// when its context is cancelled before any message arrives. Pre-cancels the
+// ctx, subscribes to a fresh topic with no messages, and asserts Run exits
+// within a short deadline. Catches regressions where the loop accidentally
+// blocks on ReadMessage instead of checking ctx.Err().
+func TestConsumer_CtxCancelExitsCleanly(t *testing.T) {
+	ctx := context.Background()
+
+	bootstrap, terminate := startKafka(t, ctx)
+	defer terminate()
+
+	const idleTopic = "idle-topic"
+	createTopic(t, ctx, bootstrap, idleTopic)
+
+	consumerCtx, consumerCancel := context.WithCancel(ctx)
+	consumerCancel() // pre-cancelled — Run should exit on the first ctx.Err() check
+
+	done := make(chan error, 1)
+	go func() {
+		done <- consumer.Run(consumerCtx, consumer.Config{
+			KafkaConfig: kafka.ConfigMap{"bootstrap.servers": bootstrap},
+			Topic:       idleTopic,
+			GroupID:     "ctx-cancel-test",
+			PollTimeout: 50 * time.Millisecond,
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v on pre-cancelled ctx; want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not exit within 10s after ctx cancellation")
+	}
+}
+
+// TestConsumer_MaxMessagesEarlyReturn verifies that Run returns after
+// MaxMessages have been consumed even when more messages remain available.
+// Produces N+5 events and asks the consumer for N — Run must stop at N
+// without continuing to drain the topic.
+func TestConsumer_MaxMessagesEarlyReturn(t *testing.T) {
+	ctx := context.Background()
+
+	bootstrap, terminate := startKafka(t, ctx)
+	defer terminate()
+
+	const cappedTopic = "capped-topic"
+	createTopic(t, ctx, bootstrap, cappedTopic)
+
+	const want = 3
+	const produced = want + 5
+	producerCtx, producerCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer producerCancel()
+	if err := producer.Run(producerCtx, producer.Config{
+		KafkaConfig: kafka.ConfigMap{"bootstrap.servers": bootstrap},
+		Topic:       cappedTopic,
+		NumMessages: produced,
+		Users:       []string{"alice"},
+		Items:       []string{"widget"},
+		Out:         &syncBuffer{},
+	}); err != nil {
+		t.Fatalf("producer.Run: %v", err)
+	}
+
+	consumerOut := &syncBuffer{}
+	consumerCtx, consumerCancel := context.WithTimeout(ctx, consumeTimeout)
+	defer consumerCancel()
+	if err := consumer.Run(consumerCtx, consumer.Config{
+		KafkaConfig: kafka.ConfigMap{"bootstrap.servers": bootstrap},
+		Topic:       cappedTopic,
+		GroupID:     "max-messages-test",
+		MaxMessages: want,
+		PollTimeout: 100 * time.Millisecond,
+		Out:         consumerOut,
+	}); err != nil {
+		t.Fatalf("consumer.Run: %v", err)
+	}
+
+	got := strings.Count(consumerOut.String(), "Consumed event from topic "+cappedTopic)
+	if got != want {
+		t.Errorf("consumed %d events, want exactly %d (MaxMessages cap); output:\n%s",
+			got, want, consumerOut.String())
+	}
+}
+
 // startKafka boots an Apache Kafka broker in KRaft mode. The container's
 // entrypoint is overridden to block until a /tmp/advertised.env file is
 // written with KAFKA_ADVERTISED_LISTENERS pointing to the Testcontainers-

--- a/internal/producer/producer.go
+++ b/internal/producer/producer.go
@@ -37,13 +37,9 @@ type Config struct {
 	Out io.Writer
 }
 
-// Run creates a producer, emits NumMessages sample events to Topic, flushes,
-// drains delivery reports, and closes the producer. It returns early if ctx
-// is cancelled.
-func Run(ctx context.Context, cfg Config) error {
-	if cfg.Topic == "" {
-		return errors.New("producer: Topic is required")
-	}
+// applyDefaults fills zero-value fields with documented defaults. Pure;
+// no I/O. Run calls this before any kafka.Producer is constructed.
+func applyDefaults(cfg *Config) {
 	if cfg.NumMessages == 0 {
 		cfg.NumMessages = 10
 	}
@@ -53,10 +49,49 @@ func Run(ctx context.Context, cfg Config) error {
 	if len(cfg.Items) == 0 {
 		cfg.Items = defaultItems
 	}
-	out := cfg.Out
-	if out == nil {
-		out = io.Discard
+	if cfg.Out == nil {
+		cfg.Out = io.Discard
 	}
+}
+
+// produceFlusher is the minimal *kafka.Producer surface produceWithRetry
+// needs — defined locally so tests can substitute a fake without spinning
+// up a real Kafka client.
+type produceFlusher interface {
+	Produce(msg *kafka.Message, deliveryChan chan kafka.Event) error
+	Flush(timeoutMs int) int
+}
+
+// errQueueFullRetry is returned by produceWithRetry when the call should
+// be retried at the call site (after Flush has drained the local queue).
+// Treated as a sentinel — never wrapped, never propagated to callers.
+var errQueueFullRetry = errors.New("producer queue full; flushed and retrying")
+
+// produceWithRetry wraps a single Produce call. On ErrQueueFull it flushes
+// the local queue and signals a retry to the caller. Any other error is
+// logged to out and swallowed (matches the legacy best-effort semantics).
+// Returns nil on successful enqueue.
+func produceWithRetry(p produceFlusher, msg *kafka.Message, out io.Writer) error {
+	if err := p.Produce(msg, nil); err != nil {
+		var kErr kafka.Error
+		if errors.As(err, &kErr) && kErr.Code() == kafka.ErrQueueFull {
+			_, _ = fmt.Fprintln(out, "Producer queue full; flushing and retrying")
+			p.Flush(1000)
+			return errQueueFullRetry
+		}
+		_, _ = fmt.Fprintf(out, "Failed to produce message: %v\n", err)
+	}
+	return nil
+}
+
+// Run creates a producer, emits NumMessages sample events to Topic, flushes,
+// drains delivery reports, and closes the producer. It returns early if ctx
+// is cancelled.
+func Run(ctx context.Context, cfg Config) error {
+	if cfg.Topic == "" {
+		return errors.New("producer: Topic is required")
+	}
+	applyDefaults(&cfg)
 
 	p, err := kafka.NewProducer(&cfg.KafkaConfig)
 	if err != nil {
@@ -71,7 +106,7 @@ func Run(ctx context.Context, cfg Config) error {
 	go func() {
 		defer close(drainDone)
 		for e := range p.Events() {
-			handleEvent(out, e)
+			handleEvent(cfg.Out, e)
 		}
 	}()
 
@@ -82,26 +117,20 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 		key := cfg.Users[rand.Intn(len(cfg.Users))]  // #nosec G404 -- sample data, not security-sensitive
 		data := cfg.Items[rand.Intn(len(cfg.Items))] // #nosec G404 -- sample data, not security-sensitive
-		if err := p.Produce(&kafka.Message{
+		msg := &kafka.Message{
 			TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
 			Key:            []byte(key),
 			Value:          []byte(data),
-		}, nil); err != nil {
-			var kErr kafka.Error
-			if errors.As(err, &kErr) && kErr.Code() == kafka.ErrQueueFull {
-				_, _ = fmt.Fprintln(out, "Producer queue full; flushing and retrying")
-				p.Flush(1000)
-				n--
-				continue
-			}
-			_, _ = fmt.Fprintf(out, "Failed to produce message: %v\n", err)
+		}
+		if err := produceWithRetry(p, msg, cfg.Out); errors.Is(err, errQueueFullRetry) {
+			n--
 		}
 	}
 
 	// Flush waits for all queued messages to be delivered AND for the drain
 	// goroutine above to consume the resulting delivery reports.
 	for p.Flush(1000) > 0 {
-		_, _ = fmt.Fprintln(out, "Still waiting to flush outstanding messages")
+		_, _ = fmt.Fprintln(cfg.Out, "Still waiting to flush outstanding messages")
 		if err := ctx.Err(); err != nil {
 			break
 		}

--- a/internal/producer/producer_test.go
+++ b/internal/producer/producer_test.go
@@ -3,8 +3,12 @@ package producer
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
@@ -13,6 +17,57 @@ func TestRun_MissingTopicReturnsError(t *testing.T) {
 	err := Run(context.Background(), Config{})
 	if err == nil || !strings.Contains(err.Error(), "Topic is required") {
 		t.Fatalf("Run({}) error = %v, want error containing %q", err, "Topic is required")
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Config
+		want Config
+	}{
+		{
+			name: "all zero — fills every default",
+			in:   Config{},
+			want: Config{
+				NumMessages: 10,
+				Users:       defaultUsers,
+				Items:       defaultItems,
+				Out:         io.Discard,
+			},
+		},
+		{
+			name: "explicit fields preserved",
+			in: Config{
+				NumMessages: 3,
+				Users:       []string{"alice"},
+				Items:       []string{"thing"},
+			},
+			want: Config{
+				NumMessages: 3,
+				Users:       []string{"alice"},
+				Items:       []string{"thing"},
+				Out:         io.Discard,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in
+			applyDefaults(&got)
+			if got.NumMessages != tt.want.NumMessages {
+				t.Errorf("NumMessages = %d, want %d", got.NumMessages, tt.want.NumMessages)
+			}
+			if !reflect.DeepEqual(got.Users, tt.want.Users) {
+				t.Errorf("Users = %v, want %v", got.Users, tt.want.Users)
+			}
+			if !reflect.DeepEqual(got.Items, tt.want.Items) {
+				t.Errorf("Items = %v, want %v", got.Items, tt.want.Items)
+			}
+			if got.Out == nil {
+				t.Error("Out is nil; want io.Discard")
+			}
+		})
 	}
 }
 
@@ -40,5 +95,120 @@ func TestHandleEvent(t *testing.T) {
 				t.Errorf("handleEvent output %q, want substring %q", buf.String(), tt.wantSubstr)
 			}
 		})
+	}
+}
+
+// fakeProducer is a produceFlusher used to drive produceWithRetry through
+// branches that a real broker can't reliably trigger (specifically
+// ErrQueueFull, which librdkafka only emits under sustained backpressure
+// against a slow broker — not realistic in tests).
+type fakeProducer struct {
+	produceErrs   []error // errors to return from successive Produce calls
+	produceCalls  int
+	flushReturns  []int // values to return from successive Flush calls
+	flushCalls    int
+	deliveredMsgs []*kafka.Message
+}
+
+func (f *fakeProducer) Produce(msg *kafka.Message, _ chan kafka.Event) error {
+	defer func() { f.produceCalls++ }()
+	if f.produceCalls < len(f.produceErrs) {
+		return f.produceErrs[f.produceCalls]
+	}
+	f.deliveredMsgs = append(f.deliveredMsgs, msg)
+	return nil
+}
+
+func (f *fakeProducer) Flush(_ int) int {
+	defer func() { f.flushCalls++ }()
+	if f.flushCalls < len(f.flushReturns) {
+		return f.flushReturns[f.flushCalls]
+	}
+	return 0
+}
+
+func TestProduceWithRetry(t *testing.T) {
+	topic := "t"
+	msg := &kafka.Message{
+		TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
+		Key:            []byte("k"),
+		Value:          []byte("v"),
+	}
+
+	t.Run("ErrQueueFull → flush + signal retry", func(t *testing.T) {
+		fp := &fakeProducer{
+			produceErrs: []error{kafka.NewError(kafka.ErrQueueFull, "queue full", false)},
+		}
+		var buf bytes.Buffer
+		err := produceWithRetry(fp, msg, &buf)
+		if !errors.Is(err, errQueueFullRetry) {
+			t.Fatalf("err = %v, want errQueueFullRetry", err)
+		}
+		if fp.flushCalls != 1 {
+			t.Errorf("flushCalls = %d, want 1", fp.flushCalls)
+		}
+		if !strings.Contains(buf.String(), "queue full; flushing and retrying") {
+			t.Errorf("missing retry log line; got %q", buf.String())
+		}
+	})
+
+	t.Run("Other Produce error is logged and swallowed", func(t *testing.T) {
+		fp := &fakeProducer{
+			produceErrs: []error{kafka.NewError(kafka.ErrUnknownTopic, "no topic", false)},
+		}
+		var buf bytes.Buffer
+		err := produceWithRetry(fp, msg, &buf)
+		if err != nil {
+			t.Errorf("err = %v, want nil (best-effort swallow)", err)
+		}
+		if fp.flushCalls != 0 {
+			t.Errorf("flushCalls = %d, want 0 (Flush only on ErrQueueFull)", fp.flushCalls)
+		}
+		if !strings.Contains(buf.String(), "Failed to produce message") {
+			t.Errorf("missing failure log line; got %q", buf.String())
+		}
+	})
+
+	t.Run("Successful Produce returns nil with no flush", func(t *testing.T) {
+		fp := &fakeProducer{}
+		var buf bytes.Buffer
+		err := produceWithRetry(fp, msg, &buf)
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+		if fp.produceCalls != 1 {
+			t.Errorf("produceCalls = %d, want 1", fp.produceCalls)
+		}
+		if fp.flushCalls != 0 {
+			t.Errorf("flushCalls = %d, want 0 on happy path", fp.flushCalls)
+		}
+	})
+}
+
+// TestRun_BrokerUnreachable_ExitsOnCtxCancel verifies Run honors ctx
+// cancellation when the broker can't be reached. librdkafka's lazy
+// connection model means kafka.NewProducer succeeds; the Produce calls
+// queue locally, Flush eventually times out per iteration, and the loop
+// continues. ctx-cancel is the only termination signal in this scenario.
+func TestRun_BrokerUnreachable_ExitsOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{
+			KafkaConfig: kafka.ConfigMap{"bootstrap.servers": "127.0.0.1:1"},
+			Topic:       "unreachable-topic",
+			NumMessages: 2,
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v on ctx-cancel; want nil", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Run did not exit within 15s after ctx cancellation")
 	}
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,3 +1,7 @@
+// Package util holds the env-var → kafka.ConfigMap plumbing shared between
+// the producer and consumer entrypoints. Splitting it out here makes the
+// main() functions a thin shell and lets the env-handling logic be unit
+// tested without spawning subprocesses.
 package util
 
 import (
@@ -9,52 +13,85 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
-const SaslUserNameEnv = "SASL_USERNAME"
-const SaslUserName = "sasl.username"
-const SaslPwdEnv = "SASL_PASSWORD"
-const SaslPwd = "sasl.password"
-const KafkaConfigFileEnv = "KAFKA_CONFIG_FILE"
-const KafkaTopicEnv = "KAFKA_TOPIC"
+const (
+	SaslUserNameEnv    = "SASL_USERNAME"
+	SaslUserName       = "sasl.username"
+	SaslPwdEnv         = "SASL_PASSWORD"
+	SaslPwd            = "sasl.password"
+	KafkaConfigFileEnv = "KAFKA_CONFIG_FILE"
+	KafkaTopicEnv      = "KAFKA_TOPIC"
+	// NumMessagesEnv is read by the producer entrypoint to override the
+	// default Config.NumMessages (10). E2E harnesses set this to fix the
+	// publish count for assertion-counting purposes.
+	NumMessagesEnv = "NUM_MESSAGES"
+)
 
+// EnvLookup is the minimal env-reader contract — `os.Getenv` satisfies it
+// directly, and tests pass a map-backed implementation.
+type EnvLookup func(string) string
+
+// ReadEnvVar returns the value of key. Empty string when unset; logs a
+// notice to stdout in that case to surface unset-required-vars at boot.
 func ReadEnvVar(key string) string {
 	val, ok := os.LookupEnv(key)
 	if !ok {
 		fmt.Printf("%s not set\n", key)
 		return ""
-	} else {
-		return val
 	}
+	return val
 }
 
-func ReadConfig(configFile string) kafka.ConfigMap {
-
-	m := make(map[string]kafka.ConfigValue)
-
+// ReadConfig parses a Java-style .properties file into a kafka.ConfigMap.
+// Returns an error on missing file, scanner failure, or any other read
+// problem so callers can decide how to surface the error (vs. the legacy
+// os.Exit-on-error which made the function untestable).
+func ReadConfig(configFile string) (kafka.ConfigMap, error) {
 	file, err := os.Open(configFile) // #nosec G304 -- configFile sourced from trusted KAFKA_CONFIG_FILE env var
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to open file: %s", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("open %s: %w", configFile, err)
 	}
 	defer func() { _ = file.Close() }()
 
+	m := make(kafka.ConfigMap)
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, "#") && len(line) != 0 {
-			before, after, found := strings.Cut(line, "=")
-			if found {
-				parameter := strings.TrimSpace(before)
-				value := strings.TrimSpace(after)
-				m[parameter] = value
-			}
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
 		}
+		before, after, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		m[strings.TrimSpace(before)] = strings.TrimSpace(after)
 	}
-
 	if err := scanner.Err(); err != nil {
-		fmt.Printf("Failed to read file: %s", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("read %s: %w", configFile, err)
 	}
+	return m, nil
+}
 
-	return m
-
+// BuildKafkaConfigMap is the canonical env-var-to-ConfigMap translation
+// used by both producer and consumer entrypoints: read the .properties
+// file path from KAFKA_CONFIG_FILE, parse it, then layer in SASL
+// credentials from SASL_USERNAME / SASL_PASSWORD env vars. Returns the
+// merged ConfigMap and the topic from KAFKA_TOPIC.
+//
+// Pass `os.Getenv` for production; tests pass a map-backed fake.
+func BuildKafkaConfigMap(lookup EnvLookup) (kafka.ConfigMap, string, error) {
+	configFile := lookup(KafkaConfigFileEnv)
+	if configFile == "" {
+		return nil, "", fmt.Errorf("%s is required", KafkaConfigFileEnv)
+	}
+	conf, err := ReadConfig(configFile)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := conf.SetKey(SaslUserName, lookup(SaslUserNameEnv)); err != nil {
+		return nil, "", fmt.Errorf("set %s: %w", SaslUserName, err)
+	}
+	if err := conf.SetKey(SaslPwd, lookup(SaslPwdEnv)); err != nil {
+		return nil, "", fmt.Errorf("set %s: %w", SaslPwd, err)
+	}
+	return conf, lookup(KafkaTopicEnv), nil
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -77,7 +78,10 @@ func TestReadConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			got := ReadConfig(path)
+			got, err := ReadConfig(path)
+			if err != nil {
+				t.Fatalf("ReadConfig(%q): %v", path, err)
+			}
 			if len(got) != len(tt.want) {
 				t.Fatalf("len(ReadConfig) = %d, want %d — got: %v", len(got), len(tt.want), got)
 			}
@@ -100,9 +104,22 @@ func TestReadConfig_EmptyFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	got := ReadConfig(path)
+	got, err := ReadConfig(path)
+	if err != nil {
+		t.Fatalf("ReadConfig(empty): %v", err)
+	}
 	if len(got) != 0 {
 		t.Errorf("empty file: got %v, want empty map", got)
+	}
+}
+
+func TestReadConfig_FileNotFound(t *testing.T) {
+	_, err := ReadConfig(filepath.Join(t.TempDir(), "does-not-exist.properties"))
+	if err == nil {
+		t.Fatal("ReadConfig(missing): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "open") {
+		t.Errorf("error message %q does not mention open()", err.Error())
 	}
 }
 
@@ -123,3 +140,59 @@ func TestConstants(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildKafkaConfigMap(t *testing.T) {
+	dir := t.TempDir()
+	props := filepath.Join(dir, "kafka.properties")
+	if err := os.WriteFile(props, []byte("bootstrap.servers=broker:9092\nsecurity.protocol=SASL_SSL\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("happy path merges file + env credentials", func(t *testing.T) {
+		env := mapLookup{
+			KafkaConfigFileEnv: props,
+			SaslUserNameEnv:    "user-key",
+			SaslPwdEnv:         "user-secret",
+			KafkaTopicEnv:      "demo",
+		}
+		conf, topic, err := BuildKafkaConfigMap(env.Get)
+		if err != nil {
+			t.Fatalf("BuildKafkaConfigMap: %v", err)
+		}
+		if topic != "demo" {
+			t.Errorf("topic = %q, want %q", topic, "demo")
+		}
+		// File-sourced
+		if got, _ := conf.Get("bootstrap.servers", ""); got != "broker:9092" {
+			t.Errorf("bootstrap.servers = %q, want %q", got, "broker:9092")
+		}
+		// Env-sourced
+		if got, _ := conf.Get(SaslUserName, ""); got != "user-key" {
+			t.Errorf("%s = %q, want %q", SaslUserName, got, "user-key")
+		}
+		if got, _ := conf.Get(SaslPwd, ""); got != "user-secret" {
+			t.Errorf("%s = %q, want %q", SaslPwd, got, "user-secret")
+		}
+	})
+
+	t.Run("missing config-file env returns error", func(t *testing.T) {
+		env := mapLookup{}
+		_, _, err := BuildKafkaConfigMap(env.Get)
+		if err == nil || !strings.Contains(err.Error(), KafkaConfigFileEnv) {
+			t.Fatalf("err = %v, want error mentioning %s", err, KafkaConfigFileEnv)
+		}
+	})
+
+	t.Run("nonexistent config file surfaces open error", func(t *testing.T) {
+		env := mapLookup{KafkaConfigFileEnv: filepath.Join(dir, "missing.properties")}
+		_, _, err := BuildKafkaConfigMap(env.Get)
+		if err == nil || !strings.Contains(err.Error(), "open") {
+			t.Fatalf("err = %v, want open() error", err)
+		}
+	})
+}
+
+// mapLookup is a tiny test helper that satisfies EnvLookup from a map.
+type mapLookup map[string]string
+
+func (m mapLookup) Get(key string) string { return m[key] }

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -1,34 +1,42 @@
+// Producer entrypoint. The thin shell here delegates env-var translation
+// to internal/util.BuildKafkaConfigMap (testable, returns errors instead
+// of os.Exit) and the produce loop to internal/producer.Run (testable,
+// driven by ctx + Config).
 package main
 
 import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/AndriyKalashnykov/go-kafka-confluent-examples/internal/producer"
 	"github.com/AndriyKalashnykov/go-kafka-confluent-examples/internal/util"
 )
 
 func main() {
-	configFile := util.ReadEnvVar(util.KafkaConfigFileEnv)
-	conf := util.ReadConfig(configFile)
-
-	if err := conf.SetKey(util.SaslUserName, util.ReadEnvVar(util.SaslUserNameEnv)); err != nil {
-		fmt.Printf("Failed to set %s: %s\n", util.SaslUserName, err)
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	if err := conf.SetKey(util.SaslPwd, util.ReadEnvVar(util.SaslPwdEnv)); err != nil {
-		fmt.Printf("Failed to set %s: %s\n", util.SaslPwd, err)
-		os.Exit(1)
-	}
+}
 
-	topic := util.ReadEnvVar(util.KafkaTopicEnv)
-	if err := producer.Run(context.Background(), producer.Config{
+func run() error {
+	conf, topic, err := util.BuildKafkaConfigMap(os.Getenv)
+	if err != nil {
+		return fmt.Errorf("producer: build config: %w", err)
+	}
+	cfg := producer.Config{
 		KafkaConfig: conf,
 		Topic:       topic,
 		Out:         os.Stdout,
-	}); err != nil {
-		fmt.Printf("Producer failed: %s\n", err)
-		os.Exit(1)
 	}
+	if v := os.Getenv(util.NumMessagesEnv); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("producer: invalid %s=%q: %w", util.NumMessagesEnv, v, err)
+		}
+		cfg.NumMessages = n
+	}
+	return producer.Run(context.Background(), cfg)
 }

--- a/renovate.json
+++ b/renovate.json
@@ -10,8 +10,16 @@
     "github-actions",
     "dockerfile",
     "docker-compose",
+    "kubernetes",
+    "mise",
     "custom.regex"
   ],
+  "kubernetes": {
+    "managerFilePatterns": [
+      "/^k8s/.+\\.ya?ml$/",
+      "/^e2e/k8s/.+\\.ya?ml$/"
+    ]
+  },
   "postUpdateOptions": [
     "gomodTidy"
   ],
@@ -31,6 +39,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+))?\\n\\s+[A-Z_]+:\\s*(?<currentValue>\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update inline-pinned tool versions in shell scripts via renovate comments (KIND_VERSION/KUBECTL_VERSION in scripts/kind-tools-install.sh, etc.)",
+      "managerFilePatterns": ["/^scripts/.*\\.sh$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+=\"\\$\\{[A-Z_]+:-(?<currentValue>[^}]+)\\}\""
+      ]
     }
   ],
   "commitMessagePrefix": "chore(all): ",
@@ -43,7 +59,7 @@
   "prHourlyLimit": 0,
   "platformAutomerge": true,
   "automerge": true,
-  "automergeType": "branch",
+  "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
   "vulnerabilityAlerts": {
@@ -91,6 +107,24 @@
         "docker"
       ],
       "groupName": "Docker dependencies"
+    },
+    {
+      "description": "Group mise-managed lint and security scanners (golangci-lint, gosec, gitleaks, hadolint, trivy, actionlint, shellcheck, govulncheck, act)",
+      "matchManagers": [
+        "mise"
+      ],
+      "matchPackageNames": [
+        "/golangci-lint/",
+        "/gosec/",
+        "/gitleaks/",
+        "/hadolint/",
+        "/trivy/",
+        "/actionlint/",
+        "/shellcheck/",
+        "/govulncheck/",
+        "/nektos\\/act/"
+      ],
+      "groupName": "mise lint & security tools"
     }
   ]
 }

--- a/scripts/kind-tools-install.sh
+++ b/scripts/kind-tools-install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Install kind + kubectl into ~/.local/bin so the e2e harness has the
+# tools available locally and inside CI runners (the GitHub Actions
+# ubuntu-latest image preinstalls kubectl, but act's catthehacker runner
+# does not — install unconditionally for parity).
+#
+# Versions are pinned via inline `# renovate:` comments below; the same
+# constants are mirrored as step-env in .github/workflows/ci.yml so that
+# Renovate's customManagers regex covers BOTH locations.
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=kubernetes-sigs/kind
+KIND_VERSION="${KIND_VERSION:-v0.31.0}"
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.35.3}"
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+DEST="${HOME}/.local/bin"
+mkdir -p "$DEST"
+
+if ! command -v kind >/dev/null 2>&1 || [ "$(kind version 2>/dev/null | awk '{print $2}')" != "$KIND_VERSION" ]; then
+  echo "Installing kind ${KIND_VERSION}..."
+  curl -fsSLo "${DEST}/kind" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${OS}-${ARCH}"
+  chmod +x "${DEST}/kind"
+fi
+
+if ! command -v kubectl >/dev/null 2>&1 || [ "$(kubectl version --client -o json 2>/dev/null | grep -o '"gitVersion":"[^"]*"' | head -1 | cut -d'"' -f4)" != "$KUBECTL_VERSION" ]; then
+  echo "Installing kubectl ${KUBECTL_VERSION}..."
+  curl -fsSLo "${DEST}/kubectl" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${OS}/${ARCH}/kubectl"
+  chmod +x "${DEST}/kubectl"
+fi
+
+echo "kind:    $(kind version)"
+echo "kubectl: $(kubectl version --client | head -1)"


### PR DESCRIPTION
## Summary

Single coherent pass applying `/project-review` findings, `/harden-image-pipeline` Phase 3, and `/test-coverage-analysis` Phase 4. Locally verified end-to-end: `make ci`, `make e2e-compose`, `make e2e` (KinD), `make ci-run` (act) all green.

### Toolchain
- Migrate 9 host-installed tools (golangci-lint, act, hadolint, gosec, gitleaks, actionlint, shellcheck, trivy, govulncheck) into `.mise.toml` via aqua/go backends; drop the matching `_VERSION` constants and `deps-*` install blocks from the Makefile.
- Add `export PATH := $(HOME)/.local/share/mise/shims:$(HOME)/.local/bin:$(PATH)` to the Makefile so recipe sub-shells can find mise-managed binaries (Make doesn't source rc files; mise auto-activation never fires inside `$(SHELL) -c`).
- Introduce `KUBECTL ?= kubectl` indirection for production-targeting recipes (overridable: `make k8s-deploy KUBECTL='kubectl --context=my-prod-cluster'`).
- New `scripts/kind-tools-install.sh` with `# renovate:` annotations on `KIND_VERSION` + `KUBECTL_VERSION` (replaces inline workflow install).
- Smaller fixes: lint no longer masks hadolint errors with `|| true`, `make help` no longer prompts for a tag at parse time, `deps-prune-check` traps backups, `release` recipe moved out of make-parse time, `define load_env` dead code removed.

### CI workflow
- Drop trigger-level `paths-ignore` deadlock; add `changes` job using SHA-pinned `dorny/paths-filter@v4.0.1`. Heavy jobs gate on `if: success() && needs.changes.outputs.code == 'true'` (the `success() &&` is required because explicit `if:` strips the implicit `success()` check).
- Replace `actions/setup-go` with `jdx/mise-action@v4.0.1` + `actions/cache@v5.0.5` for Go modules (portfolio-mandatory mise-action pattern).
- `e2e` + `e2e-compose` now `needs: [..., build, test]` for fail-fast.
- **`docker` job restructured: per-push run with step-level tag-gating.** Job runs every code-changing push (multi-arch validation build + Trivy + smoke); push to ghcr.io gated by `push: ${{ startsWith(github.ref, 'refs/tags/') }}`; Login / Cosign-install / Sign steps gated by step-level `if:`. Catches arm64 cross-compile + cosign-installer regressions on the introducing commit, not tag day. Job-level `if:` uses `success() && (...)` so skipped `release-binaries` on non-tag pushes doesn't cascade-skip docker.
- `flavor: latest=${{ startsWith(github.ref, 'refs/tags/') }}` (was hardcoded `latest=true`).
- GHCR namespace switched to `ghcr.io/<owner>/<repo>/<package>` (user-account repos cannot bootstrap user-namespace packages with `GITHUB_TOKEN`).

### Renovate
- `automergeType: "branch"` → `"pr"` (main has the `ci-pass` ruleset-required check; branch automerge silently breaks against rulesets).
- Enable `kubernetes` + `mise` managers; add custom regex for shell-script tool pins.

### Code refactors (testability)
- `internal/util.ReadConfig` returns error instead of `os.Exit(1)`.
- New `internal/util.BuildKafkaConfigMap(EnvLookup)` — env-vars → `kafka.ConfigMap` + topic, testable with map-backed fakes. Adds `NumMessagesEnv` constant.
- `internal/consumer.Run`: extract pure `applyDefaults(*Config)` helper.
- `internal/producer.Run`: extract `applyDefaults` + `produceWithRetry` (with local `produceFlusher` interface for fake injection).
- `producer/producer.go` + `consumer/consumer.go`: thin `main → run()` pattern; single `util.BuildKafkaConfigMap` call replaces the env-read + `SetKey` ladder. Producer reads `NUM_MESSAGES` env override.
- `e2e/e2e-kind-test.sh`: `KUBECTL=(kubectl --context=kind-${CLUSTER})` array (defends against sibling project's `kubectl config use-context` overwriting current-context globally). 3× retry loop on apache/kafka rollout-status absorbs docker.io anonymous pull rate-limit hiccups.

### Test coverage (Phase 4 results)
| Package | Before | After |
|---------|--------|-------|
| `internal/consumer` | 5% | **77%** |
| `internal/producer` | 17% | **94%** |
| `internal/util` | 84% | **91%** |

New tests:
- `TestApplyDefaults` (consumer + producer) — table-driven, covers every defaulting branch.
- `TestProduceWithRetry` — drives `ErrQueueFull` retry, other-error swallow, happy path via `fakeProducer`.
- `TestRun_BrokerUnreachable_ExitsOnCtxCancel` (consumer + producer) — verifies ctx-cancel honored when broker unreachable.
- `TestReadConfig_FileNotFound` + `TestBuildKafkaConfigMap` (3 sub-cases).
- `TestConsumer_CtxCancelExitsCleanly` + `TestConsumer_MaxMessagesEarlyReturn` (integration, real broker via Testcontainers).

### E2E producer-binary path
- New `Dockerfile.producer` mirrors the consumer's CGO/librdkafka build.
- `e2e/docker-compose.e2e.yml`: new `producer` service with `profiles: [producer]` so it doesn't start under `compose up`. Harness invokes via `compose --profile producer run --rm producer` with `NUM_MESSAGES=5`. Both binaries now exercised end-to-end (previously only consumer was — `kafka-console-producer.sh` shortcut bypassed the producer binary entirely).

### Documentation
- README.md: bump `confluent-kafka-go v2.14.0 → v2.14.1`, add prose captions under hero + sequence diagrams, add missing Make Targets rows, rewrite CI/CD job table, update cosign verify URL.
- CLAUDE.md: same version bump, expand mise description, document three-layer test pyramid + KUBECTL split rationale + `NUM_MESSAGES` env var.
- Dockerfile.consumer: remove ~16 lines of commented-out legacy librdkafka build steps; replace with a 4-line linkage note.

### Tooling
- New `.dockerignore`: minimal exclusion list (`.git`, `.bin`, `dist`, `.env`, `kafka.properties`, `.claude`, `.mise`, IDE state).

## Test plan

- [x] `make ci` (static-check + test + integration-test + build) — coverage report shows the 5%→77% / 17%→94% / 84%→91% jumps
- [x] `make e2e-compose` — both Dockerfiles built; producer binary publishes 5 events through `producer.Run`; consumer processes all 5
- [x] `make e2e` (KinD) — kubectl context array works; 3× retry loop tolerates docker.io hiccups
- [x] `make ci-run` (act, full GH Actions workflow) — exit 0
- [x] `make lint` — `0 issues`, hadolint clean against both Dockerfiles
- [x] `npx renovate --platform=local` — 11 files / 116+ deps tracked across `gomod`, `dockerfile`, `docker-compose`, `kubernetes`, `mise`, `github-actions`, `regex`
- [ ] Verify on real GH Actions: `changes` detector classifies code/docs correctly; `docker` job runs on every code-push (validation only); on next tag push, GHCR repo-namespace bootstrap succeeds and cosign signs