### PR TITLE
chore: compact C4Context hero + datasource-scoped mise release-age buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,13 @@
 Reference implementation of a [Confluent Cloud](https://confluent.cloud/) Kafka producer and consumer in Go using the [confluent-kafka-go](https://github.com/confluentinc/confluent-kafka-go/) client. Demonstrates CGO-linked `librdkafka` builds, Kubernetes `ConfigMap`/`Secret` credential injection, Docker Compose local runtime, and GoReleaser cross-compilation for Linux + macOS — validated by a three-layer test pyramid (unit, Testcontainers integration, KinD + Compose e2e) and a supply-chain–hardened GitHub Actions pipeline (Trivy image scan, cosign keyless OIDC signing).
 
 ```mermaid
-C4Context
-  title System Context — go-kafka-confluent-examples
+flowchart LR
+  dev(["Developer / Operator<br/>runs binaries locally or deploys to k8s"])
+  sys["<b>Kafka Producer &amp; Consumer</b><br/>two Go CLIs (CGO / librdkafka)<br/>publish &amp; subscribe to a topic"]
+  ccloud[("Confluent Cloud<br/>managed Kafka · SASL/PLAIN over TLS 9092")]
 
-  Person(dev, "Developer / Operator", "Runs binaries locally or deploys to Kubernetes")
-  System(sys, "Kafka Producer & Consumer", "Two Go CLIs publishing and subscribing to a Confluent Cloud topic")
-  System_Ext(ccloud, "Confluent Cloud", "Managed Kafka cluster (SASL/PLAIN over TLS 9092)")
-
-  Rel(dev, sys, "Builds, runs, deploys", "make / docker / kubectl")
-  Rel(sys, ccloud, "Produces & consumes", "Kafka protocol, SASL_SSL")
-
-  UpdateLayoutConfig($c4ShapeInRow="3")
+  dev -->|builds · runs · deploys<br/>make / docker / kubectl| sys
+  sys -->|produces &amp; consumes<br/>Kafka · SASL_SSL| ccloud
 ```
 
 A developer builds the producer and consumer binaries (or the consumer container image) and points them at a Confluent Cloud cluster. Authentication is SASL/PLAIN over TLS on port 9092; credentials live in `.env` locally and in a Kubernetes `Secret` when deployed.

--- a/renovate.json
+++ b/renovate.json
@@ -116,7 +116,16 @@
         "/govulncheck/",
         "/nektos\\/act/"
       ],
-      "groupName": "mise lint & security tools",
+      "groupName": "mise lint & security tools"
+    },
+    {
+      "description": "Hold every github-tags-tracked mise tool (the aqua: lint/security scanners) for 3 days so the upstream GitHub Release artifacts mise installs are published before the bump PR opens — prevents the tag-before-publish 404. Scoped by datasource so it covers all current AND future aqua tools without coupling to the lint grouping or touching the go/node core pins.",
+      "matchManagers": [
+        "mise"
+      ],
+      "matchDatasources": [
+        "github-tags"
+      ],
       "minimumReleaseAge": "3 days"
     },
     {


### PR DESCRIPTION
## Summary
- **Diagrams**: convert the C4Context **hero** to a `flowchart LR` — it rendered **752×874** (an 874px portrait tower; `$c4ShapeInRow` is a no-op for Mermaid C4, same as the Container view fixed in #111). Measured **1192×190** after — a clean wide hero. All 3 README diagrams are now right-sized (Container 1183×634, sequence 980×653).
- **Renovate**: move the mise tag-before-publish buffer off the lint-group rule onto a dedicated `{matchManagers:["mise"], matchDatasources:["github-tags"], minimumReleaseAge:"3 days"}` rule, so it covers every current AND future aqua tool without coupling to the grouping (skill-canonical form).

## Validation
- Rendered all 3 Mermaid blocks via `minlag/mermaid-cli` and **measured** the viewBox (hero 874px → 190px); `make mermaid-lint` green.
- `renovate --platform=local`: no `validationError`.
- `docker` job is tag-only (from #111), so this doc/config PR skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)