### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,12 @@ release:
 	if ! echo "$$NT" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
 		echo "Error: tag '$$NT' is not valid semver (expected vMAJOR.MINOR.PATCH)"; exit 1; \
 	fi; \
+	if git rev-parse -q --verify "refs/tags/$$NT" >/dev/null 2>&1; then \
+		echo "ERROR: tag $$NT already exists locally. Pick a new version or delete it: git tag -d $$NT"; exit 1; \
+	fi; \
+	if git ls-remote --exit-code --tags origin "refs/tags/$$NT" >/dev/null 2>&1; then \
+		echo "ERROR: tag $$NT already exists on origin. Pick a new version."; exit 1; \
+	fi; \
 	read -r -p "Are you sure to create and push $$NT tag? [y/N] " ans; \
 	if [ "$${ans:-N}" != "y" ]; then echo "Aborted."; exit 1; fi; \
 	echo "$$NT" > ./version.txt && \


### PR DESCRIPTION
The `release` recipe wrote `version.txt`, staged and committed **before** `git tag`, with no pre-existence check. Re-running with an existing tag lands a dangling "Cut vX release" commit while `git tag` aborts — a half-published release.

This adds local (`git rev-parse --verify`) and remote (`git ls-remote --exit-code --tags`) tag guards right after semver validation and before the confirm prompt / first mutation, so the target fails fast and creates no commit.

Verified: `make -n release` parses; feeding an existing tag (`v0.0.9`) to the recipe errors at the guard before any commit/tag, leaving the tree clean.

Implements Safety Check #16 from the /makefile skill.